### PR TITLE
Allison comments

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -10,5 +10,7 @@
     <li class="uppercase"><a href="/module_two">Module 2</a></li>
     <li class="uppercase"><a href="/module_three">Module 3</a></li>
     <li class="uppercase"><a href="/module_four">Module 4</a></li>
+    <li class="uppercase"><a href="/module-5">Module 5</a></li>
+    <li class="uppercase"><a href="/resources">Resources</a></li>
   </ul>
 </nav>

--- a/_sass/home-page.scss
+++ b/_sass/home-page.scss
@@ -1,7 +1,7 @@
 .splash {
   background: url('/assets/images/home-page-splash.jpg') 100%;
   background-size: cover;
-  border-bottom: 8px solid $front-end-primary;
+  border-bottom: 8px solid $turing-primary;
   height: 525px;
   display: flex;
   align-items: center;

--- a/_sass/sidebar.scss
+++ b/_sass/sidebar.scss
@@ -8,7 +8,7 @@ nav {
 
 .nav-links {
   display: grid;
-  grid-template-columns: auto 100px 100px 100px 100px;
+  grid-template-columns: auto 100px 100px 100px 100px 100px 100px;
   grid-template-rows: 120px;
   align-items: center;
   justify-items: center;

--- a/index.html
+++ b/index.html
@@ -6,25 +6,62 @@ title: Career Development Curriculum
 <section class="splash">
   <div class="splash-text">
     <h1>Career Development Curriculum</h1>
-    <p>Your guide to OOP, Ruby, Rails, databases, and more.</p>
+    <p>Your guide to a successful new career in software.</p>
   </div>
 </section>
 
-<section class="resources-section section-light">
-  <h2>Daily Turing</h2>
-  <p>See your calendar, go through your daily lessons or professional developement, and then take a look at the projects you'll be building.</p>
+<!-- <section class="resources-section section-light">
+  <h2>Our Curriculum</h2>
+  <a class="btn btn-dark" href="/additional_resources/mental_health_resources">Mission</a>
+  <a class="btn btn-dark" href="/additional_resources/mental_health_resources">Touchstones</a>
+  <a class="btn btn-dark" href="/additional_resources/mental_health_resources">Overview</a>
+  <a class="btn btn-dark" href="/additional_resources/mental_health_resources">Structure</a>
+</section> -->
 
-  <a class="btn btn-dark" href="/additional_resources/calendars">Calendar</a>
-  <a class="btn btn-dark" href="/additional_resources/mental_health_resources">Mental Health</a>
-  <a class="btn btn-dark" href="/professional_development">Professional Development</a>
-  <a class="btn btn-dark" href="/additional_resources/mentors">Mentor List</a>
+<section class="content">
+  <article>
+    <h2>Mission</h2>
+    <p>Turing’s mission is to <em>unlock human potential</em> by training a diverse, inclusive student body to <em>succeed in high-fulfillment technical careers.</em></p>
+    <p>Turing’s career development curriculum is created directly out of this mission with a focus on <em>unlocking students’ potential</em> in modules one and two through cultivating self-awareness and empathy. In modules three and four, curriculum focuses on providing strategies to empower students to <em>succeed in high-fulfillment technical careers</em> by creating connections within the technology industry, building competencies for industry leadership, and securing a fulfilling career — and not just another job.</p>
+  </article>
+
 </section>
 
-<section class="resources-section section-dark">
-  <h2>Paired</h2>
-  <p>Join the app created by fellow Turing students to help you schedule pairings with each other. <a target="_blank" rel="noopener" href="http://paired.tech">Try it out!</a></p>
+<section class="content">
+  <article>
+    <h2>Touchstones</h2>
+    <p>The touchstones of this curriculum include developing these mindsets:</p>
 
-  <img src="https://paired-turing.firebaseapp.com/static/media/code-typing.be92109b.svg" alt="Paired logo">
+    <ul>
+      <li><em>Agency:</em> Taking initiative and ownership over your learning and work</li>
+      <li><em>Empathy:</em> Understanding and sharing others' emotions in order to relate to them</li>
+      <li><em>Engagement:</em> Active participation in community</li>
+      <li><em>Grit:</em> A combination of perseverance and passion</li>
+      <li><em>Growth:</em> A belief that your abilities can be developed through dedication, hard work, and resiliency</li>
+    </ul>
+  </article>
+</section>
+
+
+<section class="content">
+  <article>
+    <h2>Overview</h2>
+    <ul>
+      <li><em>Mod 1:</em> Create your vision for your career and establish habits to help you reach goals for you to get there</li>
+      <li><em>Mod 2:</em> Refine your vision and implement branding and job search strategies to share your story and vision with others through networking</li>
+      <li><em>Mod 3:</em> Execute your strategy, phase I: resume, cover letters, continued strategic networking, interview skills</li>
+      <li><em>Mod 4:</em> Execute your strategy, phase II: continue utilizing and refining your strategy as you talk to companies and go on interviews</li>
+    </ul>
+  </article>
+</section>
+
+<section class="content">
+  <article>
+    <h2>Structure</h2>
+    <p>Every Monday, students will have a workshop on a specific professional development topic to provide them with support in each of these areas. The workshops will provide space for whole group and small group discussion, readings, and reflection time along with resources and strategies for implementing new ideas.</p>
+    <p>Throughout the rest of the week, students will be able to put this learning into practice through reflections in their career journals. What is a career journal? It's a document where the student can create a road map for their career goals through self-reflection, prompts, and questions.</p>
+    <p>The Career Dev team will review each students' journal reflections weekly and again at the end of each module to assess their progress and provide tailored support when needed.</p>
+  </article>
 </section>
 
 {% include footer.html %}

--- a/module-1-prework/career_journal_template.md
+++ b/module-1-prework/career_journal_template.md
@@ -7,19 +7,19 @@ title: Career Journal Template
 
 ## Overview
 * **What is a career journal?** The journal will help guide you through the process of discovering who you are as a new developer and how that translates into your career goals.  It’s a way to check in with yourself through self-reflection, prompts, and questions, organize your targeted job search, and remember who you met as you build a professional network.   
-* **Make it your own.** Add questions and areas to reflect on each week. Just don’t forget to share all of your successes and achievements along the way! 
-* **Ongoing progress checks.** Throughout each module, you'll respond to the other prompts and update your progress in your document during professional development workshops and set aside work time. 
-* **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation. 
+* **Make it your own.** Add questions and areas to reflect on each week. Just don’t forget to share all of your successes and achievements along the way!
+* **Ongoing progress checks.** Throughout each module, you'll respond to the other prompts and update your progress in your document during professional development workshops and set aside work time.
+* **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation.
 
 ### Directions
 1. Copy the following prompts into your own private gist or Google Doc. Note: when creating a gist, please make sure to add .md at the end of the title to turn it into markdown format. If you're using a Google doc, please provide comment access.
 2. Respond to the Mod 0 prompts.
-3. Submit the link to your document in [this survey](https://forms.gle/x4DCbZV64Z1ouyrY6) for the career development component of your Mod 1 Prework. 
+3. Submit the link to your document in [this survey](https://forms.gle/x4DCbZV64Z1ouyrY6) for the career development component of your Mod 1 Prework.
 
-### Mod 0 
-1. When you've worked towards a goal in the past, what systems or tools have been helpful for you in accomplishing that goal? How could you adapt those same systems/tools to use while at Turing? 
+### Mod 0
+1. When you've worked towards a goal in the past, what systems or tools have been helpful for you in accomplishing that goal? How could you adapt those same systems/tools to use while at Turing?
 
-2. As you start this new career, what is one of your strengths and how do you know? 
+2. As you start this new career, what is one of your strengths and how do you know?
 
 3. Describe how you work best (conditions, environment, preferences, etc.):
 
@@ -27,37 +27,37 @@ title: Career Journal Template
 
 5. How will developing a deeper understanding of your strengths and working preferences benefit you as a software developer?
 
-6. Describe the vision you currently have for your career after Turing: 
+6. Describe the vision you currently have for your career after Turing:
 
 ### Mod 1
 Find the prompts to Mod 1 here:
-* [Week 1](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-1)
-* [Week 2](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-2)
-* [Week 3](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-3)
-* [Week 4](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-4)
-* [Week 5](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-5)
+* [Week 1](/module_one/mod1_career_journal_prompts#week-1)
+* [Week 2](/module_one/mod1_career_journal_prompts#week-2)
+* [Week 3](/module_one/mod1_career_journal_prompts#week-3)
+* [Week 4](/module_one/mod1_career_journal_prompts#week-4)
+* [Week 5](/module_one/mod1_career_journal_prompts#week-5)
 
 ### Mod 2
 Find the prompts to Mod 2 here:
-* [Week 1](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md#week-1)
-* [Week 2](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md#week-2)
-* [Week 3](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md#week-3)
-* [Week 4](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md#week-4)
-* [Week 5](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md#week-5)
+* [Week 1](/module_two/mod2_career_journal_prompts#week-1)
+* [Week 2](/module_two/mod2_career_journal_prompts#week-2)
+* [Week 3](/module_two/mod2_career_journal_prompts#week-3)
+* [Week 4](/module_two/mod2_career_journal_prompts#week-4)
+* [Week 5](/module_two/mod2_career_journal_prompts#week-5)
 
 ### Mod 3
 Find the prompts to Mod 3 here:
-* [Week 1](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-1)
-* [Week 2](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-2)
-* [Week 3](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-3)
-* [Week 4](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-4)
-* [Week 5](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-5)
+* [Week 1](/module_three/mod3_career_journal_prompts#week-1)
+* [Week 2](/module_three/mod3_career_journal_prompts#week-2)
+* [Week 3](/module_three/mod3_career_journal_prompts#week-3)
+* [Week 4](/module_three/mod3_career_journal_prompts#week-4)
+* [Week 5](/module_three/mod3_career_journal_prompts#week-5)
 
 
 ### Mod 4
 Find the prompts to Mod 4 here:
-* [Week 1](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_four/mod4_career_journal_prompts.md#week-1)
-* [Week 2](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_four/mod4_career_journal_prompts.md#week-2)
-* [Week 3](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_four/mod4_career_journal_prompts.md#week-3)
-* [Week 4](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_four/mod4_career_journal_prompts.md#week-4)
-* [Week 5](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_four/mod4_career_journal_prompts.md#week-5)
+* [Week 1](/module_four/mod4_career_journal_prompts#week-1)
+* [Week 2](/module_four/mod4_career_journal_prompts#week-2)
+* [Week 3](/module_four/mod4_career_journal_prompts#week-3)
+* [Week 4](/module_four/mod4_career_journal_prompts#week-4)
+* [Week 5](/module_four/mod4_career_journal_prompts#week-5)

--- a/module-5/job_search_care_package.md
+++ b/module-5/job_search_care_package.md
@@ -175,7 +175,7 @@ For more, check out the [Mod 5 Outreach & Networking Refresh Markdown](outreach_
 * [Follow the steps suggested here for auditing your projects](http://backend.turing.io/module4/lessons/project_polish)
 
 ## Miscellaneous <a name="miscellaneous"></a>
-* [Tips for Writing Technical Blog Posts](/module_four/blogging_tips.md)
+* [Tips for Writing Technical Blog Posts](/module_four/blogging_tips)
 * [Open Source Guide](https://opensource.guide/)
-* [Tips for Speaking at a Meetup](/module_four/meetup_involvement_guidelines.md)
-* [Markdown on Negotiations](/module_four/negotiations.md)
+* [Tips for Speaking at a Meetup](/module_four/meetup_involvement_guidelines)
+* [Markdown on Negotiations](/module_four/negotiations)

--- a/module-5/practice_behavioral_interview_workshop.md
+++ b/module-5/practice_behavioral_interview_workshop.md
@@ -24,7 +24,7 @@ Today, we're going to talk about preparing for the behavioral interview, looking
 Participants take 10 minutes to prep their answers for these questions.
 
 ### Review
-Let's go over some interview techniques that we [first discussed in Module Three's session](/module_three/interview_workshop.md). The STAR method is an effective way to break down an answer for most interview questions:
+Let's go over some interview techniques that we [first discussed in Module Three's session](/module_three/interview_workshop). The STAR method is an effective way to break down an answer for most interview questions:
 
 * **Situation:** The interviewer wants you to present a recent challenge and situation in which you found yourself.
 * **Task:** What were you required to achieve? The interviewer will be looking to see what you were trying to achieve from the situation. Some performance development methods use “Target” rather than “Task”. Job interview candidates who describe a “Target” they set themselves instead of an externally imposed “Task” emphasize their own intrinsic motivation to perform and to develop their performance.

--- a/module_one/index.md
+++ b/module_one/index.md
@@ -15,26 +15,26 @@ Core Competencies of Module 1:
 * Creation of a career vision
 
 ### Module 1 Outcomes
-At the end of Module 1, students will have a working vision statement for their career. In Module 2, they will build on this to create a professional story, professional brand, and working job search strategy. 
+At the end of Module 1, students will have a working vision statement for their career. In Module 2, they will build on this to create a professional story, professional brand, and working job search strategy.
 
 ### Weekly Topics
 
-* Week 1: [Understanding Your Strengths](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_1_understanding_your_strengths.md)
-* Week 2: [Building Your Compass: Identity, Values, and Goals](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_2_building_your_compass.md)
-* Week 3: [Building Habits to Become a Software Developer](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_3_building_habits.md)
-* Week 4: [Creating Your Career Vision, Part I](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_4_career_vision_part_i.md)
-* Week 5: [Creating Your Career Vision, Part II](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_5_career_vision_part_ii.md)
+* Week 1: [Understanding Your Strengths](/module_one/week_1_understanding_your_strengths)
+* Week 2: [Building Your Compass: Identity, Values, and Goals](/module_one/week_2_building_your_compass)
+* Week 3: [Building Habits to Become a Software Developer](/module_one/week_3_building_habits)
+* Week 4: [Creating Your Career Vision, Part I](/module_one/week_4_career_vision_part_i)
+* Week 5: [Creating Your Career Vision, Part II](/module_one/week_5_career_vision_part_ii)
 
 ### Career Journal
-Students will engage in self-reflection and ideation in their career journals every week during a module. 
+Students will engage in self-reflection and ideation in their career journals every week during a module.
 
 **What is a career journal?** The journal will help guide you through the process of discovering who you are as a new developer and how that translates into your career goals.  It’s a way to check in with yourself through self-reflection, prompts, and questions, organize your targeted job search, and remember who you met as you build a professional network.   
-* **Make it your own.** Add questions and areas to reflect on each week. Just don’t forget to share all of your successes and achievements along the way! 
-* **Ongoing progress checks.** Throughout each module, you'll respond to the other prompts and update your progress in your document during professional development workshops and set aside work time. 
-* **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation. 
+* **Make it your own.** Add questions and areas to reflect on each week. Just don’t forget to share all of your successes and achievements along the way!
+* **Ongoing progress checks.** Throughout each module, you'll respond to the other prompts and update your progress in your document during professional development workshops and set aside work time.
+* **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation.
 
 #### Set Up
-Students will create their career journals in Mod 0 and submit them as part of their career development prework. [Here is the Module 1 set of career journal prompts.](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md)
+Students will create their career journals in Mod 0 and submit them as part of their career development prework. [Here is the Module 1 set of career journal prompts.](/module_one/mod1_career_journal_prompts)
 
 ### Repeating the Module
-For students repeating Module 1, they are not required to attend workshops again unless they would like to. They should continue to further their career development goals throughout the module, [following these guidelines and prompts for their career journals](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/m1_PD_repeat_plan.md). The Career Development team will check in with repeating students to provide guidance and answer questions. 
+For students repeating Module 1, they are not required to attend workshops again unless they would like to. They should continue to further their career development goals throughout the module, [following these guidelines and prompts for their career journals](/module_one/m1_PD_repeat_plan). The Career Development team will check in with repeating students to provide guidance and answer questions.

--- a/module_one/m1_PD_repeat_plan.md
+++ b/module_one/m1_PD_repeat_plan.md
@@ -5,7 +5,7 @@ title: PD Plan for Repeating Module 1
 
 # PD Plan for Repeating Module 1
 
-Repeating the module is an opportunity to not only solidify technical skills but also take advantage of extra time to work on your professional development and take concrete steps for your job search. 
+Repeating the module is an opportunity to not only solidify technical skills but also take advantage of extra time to work on your professional development and take concrete steps for your job search.
 
 Reminder that in Mod 1, we covered the topics of:
 
@@ -22,11 +22,11 @@ Here's the breakdown of expectations for repeating the module:
 ### Sessions
 You are **not** required to attend any of the professional development sessions you have attended previously. If you choose to attend any sessions, please plan to fully participate in activities, including breakout group discussions. Reminder of the weekly sessions:
 
-* Week 1: [Understanding Your Strengths](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_1_understanding_your_strengths.md)
-* Week 2: [Building Your Compass: Identity, Values, and Goals](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_2_building_your_compass.md)
-* Week 3: [Building Habits to Become a Software Developer](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_3_building_habits.md)
-* Week 4: [Creating Your Career Vision, Part I](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_4_career_vision_part_i.md)
-* Week 5: [Creating Your Career Vision, Part II](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_5_career_vision_part_ii.md)
+* Week 1: [Understanding Your Strengths](/module_one/week_1_understanding_your_strengths)
+* Week 2: [Building Your Compass: Identity, Values, and Goals](/module_one/week_2_building_your_compass)
+* Week 3: [Building Habits to Become a Software Developer](/module_one/week_3_building_habits)
+* Week 4: [Creating Your Career Vision, Part I](/module_one/week_4_career_vision_part_i)
+* Week 5: [Creating Your Career Vision, Part II](/module_one/week_5_career_vision_part_ii)
 
 ### Career Journal
 1. Please create a new section of your career journal and title it "Mod 1 Repeat Journal Reflections."
@@ -41,17 +41,17 @@ You are **not** required to attend any of the professional development sessions 
 
 3. Please copy and paste these prompts into your career journal:
 
-* Week 1: 
+* Week 1:
   * Reflections from last mod (what did I do well? Where can I improve?):
   * Goal(s) for the module:
   * Habit to put into place this week:
-  
+
 * Week 2:
   * Reflections on week 1 (what went well? What would you like to do better? What do you need help with?):
   * Progress on your goal(s):
   * Progress on your habit(s):
   * New ideas or changes to put into place this week:
-  
+
 * Week 3:
   * Reflections on week 2 (what went well? What would you like to do better? What do you need help with?):
   * Progress on your goal(s):
@@ -73,4 +73,4 @@ You are **not** required to attend any of the professional development sessions 
 
 **You are expected to be reflecting and responding to these weekly prompts every week during the module in your PD work time. If you have any questions about these expectations, please reach out to Allison.**
 
-Reminder that Allison is available for professional coaching. If you'd like to sign up for a session, please fill out this [request form](https://forms.gle/g84XjDuwLaBidDga9). 
+Reminder that Allison is available for professional coaching. If you'd like to sign up for a session, please fill out this [request form](https://forms.gle/g84XjDuwLaBidDga9).

--- a/module_one/week_1_understanding_your_strengths.md
+++ b/module_one/week_1_understanding_your_strengths.md
@@ -18,7 +18,7 @@ title: Understanding Your Strengths
 * Plan for how to discuss strengths and working preferences
 * Analyze opportunities for professional growth
 
-### [This Week's Career Journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-1)
+### [This Week's Career Journal](/module_one/mod1_career_journal_prompts#week-1)
 * Describe one of your strengths
 * Reflect on Pairin Top 4
 * Challenges with Strengths
@@ -26,7 +26,7 @@ title: Understanding Your Strengths
 * Continued growth
 
 ### Strengths: Why are we starting here?
-The core of developing yourself professionally is *understanding yourself* and  *being able to speak to to that understanding.* You have to understand yourself in order to know what you're striving towards professionally as well as how to advocate for what you want. 
+The core of developing yourself professionally is *understanding yourself* and  *being able to speak to to that understanding.* You have to understand yourself in order to know what you're striving towards professionally as well as how to advocate for what you want.
 
 These abilities will not only help you at Turing but in your new career as a software developer.
 
@@ -42,10 +42,10 @@ This week's focus is on strengths. It can be easier said than done to identify w
 
 **Knowledge** is something you know or have expertise in from years of study and practice
   * A way to articulate this is by using a statement starting with "I know..."
-  
+
 **Talent** refers to something that you have a *natural ability* to do well. Another way to think about it is something you were born with and have a natural preference towards.
   * A way to articulate this is by using a statement starting with "I am..."
-  
+
 Seems easy enough, right?
 
 Again, breaking down our strengths can be difficult, so let's start with looking at some examples.
@@ -55,11 +55,11 @@ You heard from our executive director, Jeff Casimir, this morning at the State o
 
 * Here his **skill** relates to his *public speaking* abilities. Jeff has honed those over the years in conference talks, on panels, in podcasts, and in speaking with students and stakeholders throughout the years at Turing.
 
-* His **knowledge** can often be summed up by his "big ideas" (his words). He is a prolific reader, especially around topics of organizational leadership and best practices for schools and organizations interested in social change. He creates connections between these ideas in his blog posts and speeches. 
+* His **knowledge** can often be summed up by his "big ideas" (his words). He is a prolific reader, especially around topics of organizational leadership and best practices for schools and organizations interested in social change. He creates connections between these ideas in his blog posts and speeches.
 
 * Now that brings us to his **talent,** which in this context relates to his ability to *engage and connect with others*. He's a connector and educator.
 
-* Combining these 3 things leads us to the **strength** known as **Inspirational Leadership,** which is defined as the ability to uplift, enliven, fill, and empower people with a compelling vision. As the founder of several programs, Jeff has cultivated and used this strength to not only further his vision but get others involved in executing it as well. 
+* Combining these 3 things leads us to the **strength** known as **Inspirational Leadership,** which is defined as the ability to uplift, enliven, fill, and empower people with a compelling vision. As the founder of several programs, Jeff has cultivated and used this strength to not only further his vision but get others involved in executing it as well.
 
 #### Example #2
 Let's look at another strength. A common strength that comes up for students in the Pairin assessment is **Persistence,** which is defined as the drive to firmly continue in a course of action, despite difficulties, opposition, or warning; stubborn determination. Pairin loves to nickname its strengths with fun names, and its reports refer to this one as "Tugboat." What does it look like in practice to be a tugboat?
@@ -68,7 +68,7 @@ Let's look at another strength. A common strength that comes up for students in 
 
 * The **knowledge** needed here would be around knowing *how to prioritize,* which comes down to the ability to know which task to focus on at a time based on practice.
 
-* The natural **talent** that might come into play here is the ability to *maintain focus* during arduous tasks. 
+* The natural **talent** that might come into play here is the ability to *maintain focus* during arduous tasks.
 
 Put together, these create the strength of persistence.
 
@@ -77,27 +77,27 @@ Breaking down strengths in this way can be easier when we already know what the 
 
 Start by thinking about *how you prefer to work.* Consider these scenarios:
 
-1. Sam prefers to spend time thinking through problems in their head and drawing out solutions before discussing them. 
+1. Sam prefers to spend time thinking through problems in their head and drawing out solutions before discussing them.
 2. Ana enjoys being challenged and working hard. She doesn't feel like her day is complete if she hasn't accomplished something. She is very motivated by the satisfaction of meeting deadlines.
 
-Based on how they like to work, how would you describe Sam and Ana’s strengths? 
+Based on how they like to work, how would you describe Sam and Ana’s strengths?
 
-**Do Now:** The first prompt in [this week's career journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-1) will ask you to think about what you skills, knowledge, and talents you combine into one of your strengths.
+**Do Now:** The first prompt in [this week's career journal](/module_one/mod1_career_journal_prompts#week-1) will ask you to think about what you skills, knowledge, and talents you combine into one of your strengths.
 
 ## Application: Using the Pairin Survey
-If you're having trouble identifying your strengths, your Pairin survey results might be able to help you. Pairin is a tool that gives you insight into 102 **coachable** and **changeable** professional skills ranging from citizenship to empathy to self awareness. The results from your survey will help you to identify some of your strengths and potential areas for growth. 
+If you're having trouble identifying your strengths, your Pairin survey results might be able to help you. Pairin is a tool that gives you insight into 102 **coachable** and **changeable** professional skills ranging from citizenship to empathy to self awareness. The results from your survey will help you to identify some of your strengths and potential areas for growth.
 
 ### Understanding the Results: Overview of Top 4 Qualities
 Your results show you top 4 qualities:
 
-1. Top Thinking Style 
+1. Top Thinking Style
 2. Most Intense Driver
 3. Highest EQ Competency
 4. Leading Virtue Class
 
 The following information comes from the [Pairin Qualities Overview](https://github.com/turingschool/career-development-curriculum/blob/master/files/Pairin%20Top%20Qualities%20Overview.pdf)
 
-#### Thinking Styles 
+#### Thinking Styles
 The Thinking Styles are characteristic ways of processing information and handling tasks. This includes how people acquire knowledge, organize thoughts, form views and opinions, apply personal value, plan, decide, solve problems, and express themselves. Thinking styles are NOT the same thing as thinking ability. These are categorized in 4 areas:
 
 * Cooperative-Practical: Team Player
@@ -105,31 +105,31 @@ The Thinking Styles are characteristic ways of processing information and handli
 * Intuitive-Conceptual
 * Objective-Analytical
 
-#### Drivers 
-Psychologist Henry Murray outlined a set of psychological needs that—-alone or in combination—-drive specific behaviors. Murray believed that everyone has the same set of needs but that individuals experience them in different intensities. These Drivers are based on Murray’s needs. The three domains (Love, Work & Growth) are derived from the core concepts of Abraham Maslow, Edgar Schein and James Sales. 
+#### Drivers
+Psychologist Henry Murray outlined a set of psychological needs that—-alone or in combination—-drive specific behaviors. Murray believed that everyone has the same set of needs but that individuals experience them in different intensities. These Drivers are based on Murray’s needs. The three domains (Love, Work & Growth) are derived from the core concepts of Abraham Maslow, Edgar Schein and James Sales.
 
 * **Love** — *to interact, connect with &  experience care for and from others*
-   * Relationship: Friend 
-   * Supportiveness: Caregiver 
-   * Flamboyance: Stand-out 
+   * Relationship: Friend
+   * Supportiveness: Caregiver
+   * Flamboyance: Stand-out
    * Deference: Loyalist
    * Support-Seeking: Reliant
 
 * **Work** — *to influence outcomes & gain mastery*
-   * Achievement: Ace Achiever 
-   * Personal Power: Director 
-   * Persistence: Tug Boat 
-   * Order: Specialist 
-   * Aggressiveness: Blaze 
+   * Achievement: Ace Achiever
+   * Personal Power: Director
+   * Persistence: Tug Boat
+   * Order: Specialist
+   * Aggressiveness: Blaze
 
 * **Growth** — *to be all that I can be in life; fulfilled purpose & potential*
-   * Change: Transformer 
-   * Independence: Maverick 
-   * Perceptivity: Searcher 
-   * Vitality: Enthusiast 
-   * Self-Blame: Microscope 
+   * Change: Transformer
+   * Independence: Maverick
+   * Perceptivity: Searcher
+   * Vitality: Enthusiast
+   * Self-Blame: Microscope
 
-#### Emotional Intelligence (EQ) Competencies 
+#### Emotional Intelligence (EQ) Competencies
 The definition of Emotional Intelligence or EQ (first advanced by researchers Peter Salavoy and John Mayer, but popularized by author Daniel Goleman) is the ability to:
 
 * Recognize, understand and manage our own emotions
@@ -137,45 +137,45 @@ The definition of Emotional Intelligence or EQ (first advanced by researchers Pe
 
 In practical terms, developing EQ means gaining awareness that emotions drive our behavior and impact people (positively and negatively) and learning to manage those emotions — both our own and others — especially when we are under pressure. The EQ framework has four categories comprising 18 competencies as outlined below.
 
-* Self-Awareness 
+* Self-Awareness
   * Emotional Self-Awareness: Self-Attuned
-  * Self-Assessment:	Self-Examiner 
+  * Self-Assessment:	Self-Examiner
   * Self-Confidence:	Self-Confident
 
-* Self-Management 
-  * Self-Control: Calm, Cool, Collected 
-  * Transparency: Glass Window 
+* Self-Management
+  * Self-Control: Calm, Cool, Collected
+  * Transparency: Glass Window
   * Achievement: Ace Achiever
-  * Initiative: Self-Starter 
-  * Optimism: Can Do Attitude 
+  * Initiative: Self-Starter
+  * Optimism: Can Do Attitude
   * Flexibility & Adaptability:	Elasticity
 
-* Social Awareness 
-  * Empathy: I “Get” You 
-  * Organizational Awareness: Group Expert 
-  * Service Orientation: At Your Service 
+* Social Awareness
+  * Empathy: I “Get” You
+  * Organizational Awareness: Group Expert
+  * Service Orientation: At Your Service
 
 * Relationship Management  
-  * Inspirational Leader: Inspirational Leader 
+  * Inspirational Leader: Inspirational Leader
   * Influential Leader: Influential Leader
-  * Enriching Others:	People Developer 
-  * Change:	Transformer 
-  * Conflict Management: Conflict Wrangler 
-  * Cooperative-Practical: Team Player 
+  * Enriching Others:	People Developer
+  * Change:	Transformer
+  * Conflict Management: Conflict Wrangler
+  * Cooperative-Practical: Team Player
 
 #### Virtue Classes
 Six broad virtues classifying 24 specific strengths that consistently emerge as “good” across history and culture. Pairin’s virtues map to Character Strengths and Virtues (Peterson, C., & Seligman, M. E. P., 2004), the work of a prestigious group of researchers who have attempted to create a systematic classification and measurement of widely valued positive traits. Their aim was to present a measure of humanist ideals of virtue in an empirical and scientific way.  
 
 Knowing your leading virtue class and associated strengths isn’t just interesting information. Research shows that tapping into character strengths can help an individual to: 1) Buffer against, manage and overcome problems, 2) Improve relationships, and 3) Enhance health and overall well-being.
 
-* Courage: Lover of Courage 
-* Humanity: Lover of Humanity 
-* Justice: Lover of Justice 
-* Transcendence:	Lover of Transcendence 
-* Wisdom & Knowledge:	Lover of Wisdom 
-* Temperance:	Lover of Moderation 
+* Courage: Lover of Courage
+* Humanity: Lover of Humanity
+* Justice: Lover of Justice
+* Transcendence:	Lover of Transcendence
+* Wisdom & Knowledge:	Lover of Wisdom
+* Temperance:	Lover of Moderation
 
-**Do Now:** In the [second prompt for your career journal this week](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-1), read through your Pairin results and reflect on what they mean to you.
+**Do Now:** In the [second prompt for your career journal this week](/module_one/mod1_career_journal_prompts#week-1), read through your Pairin results and reflect on what they mean to you.
 
 ### Opportunity for Professional Coaching
 What is professional coaching? Sometimes referred to as "career therapy," coaching provides you with the opportunity for thought partnership on goals that you have for your career. What topics could be covered? Whatever you want! Some popular topics are:
@@ -185,4 +185,4 @@ What is professional coaching? Sometimes referred to as "career therapy," coachi
 * Career transition guidance
 * Using your Pairin data for growth
 
-You can reach out to Allison (@allison_reu_singer on Slack) through [this request form](https://forms.gle/1NgEeYNX7p6jYA6G9) if you'd like to get additional reports on your Pairin strengths or to schedule a coaching session this module. All coaching sessions are completely confidential. 
+You can reach out to Allison (@allison_reu_singer on Slack) through [this request form](https://forms.gle/1NgEeYNX7p6jYA6G9) if you'd like to get additional reports on your Pairin strengths or to schedule a coaching session this module. All coaching sessions are completely confidential.

--- a/module_one/week_2_building_your_compass.md
+++ b/module_one/week_2_building_your_compass.md
@@ -14,7 +14,7 @@ subheading: Identity, Values, and Goals
 * Analyze what you bring to the tech industry
 * Utilize tools to build your compass
 
-### [This Week's Career Journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-2)
+### [This Week's Career Journal](/module_one/mod1_career_journal_prompts#week-2)
 * Power of Self-Reflection
 * Social Identity Mapping
 * Values Mapping
@@ -25,18 +25,18 @@ Throughout career development at Turing, you'll continue to be challenged to ref
 
 Take 5-7 minutes to read through [this post on the power of self-reflection](https://medium.com/publishous/the-power-of-self-reflection-c1a654ea03a)
 
-Here's [another, longer article](https://www.smashingmagazine.com/2018/01/importance-self-reflection-part-2/) that provides some additional insight into the importance of self-reflection as it relates to work and working relationships. 
+Here's [another, longer article](https://www.smashingmagazine.com/2018/01/importance-self-reflection-part-2/) that provides some additional insight into the importance of self-reflection as it relates to work and working relationships.
 
-Your [first journal prompt](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-2) this week will ask you to consider what is challenging about self-reflection and how you can continue to build it as a habit while at Turing.
+Your [first journal prompt](/module_one/mod1_career_journal_prompts#week-2) this week will ask you to consider what is challenging about self-reflection and how you can continue to build it as a habit while at Turing.
 
 ### Building a Compass
 The following ideas come from the book [Designing Your Life](https://bookshop.org/books/designing-your-life-how-to-build-a-well-lived-joyful-life/9781101875322)
 
 When you're undergoing a big life change, such as a career change, it's easy to get bogged down in all the details and numerous questions that come up about our lives -- "What do I want in life? How will I find it? Why am I here? What am I supposed to do?" Those questions can sometimes lead to analysis paralysis, and it's hard for us to move forward. So, instead of trying to answer *all* the questions at once, we're going to start with a framework -- we're going to build a compass.
 
-You're probably familiar with a compass. It's a navigational device that allows the user to understand their own direction as it relates to the cardinal directions, most notably aligning with magnetic north. Using a compass helps us orient ourselves and figure out what direction we need to head in next to make it to our destination. 
+You're probably familiar with a compass. It's a navigational device that allows the user to understand their own direction as it relates to the cardinal directions, most notably aligning with magnetic north. Using a compass helps us orient ourselves and figure out what direction we need to head in next to make it to our destination.
 
-To create your "true north," we're going to utilize a few different tools that will help you understand yourself better when it comes to your identity, values, and what the book calls "workview" and "lifeview" -- the ways in which you define what work and life are to you. 
+To create your "true north," we're going to utilize a few different tools that will help you understand yourself better when it comes to your identity, values, and what the book calls "workview" and "lifeview" -- the ways in which you define what work and life are to you.
 
 In summary, building a compass will allow you to move from the dysfunctional belief of **"I should already know where I'm going,"** which is a fixed mindset approach to understanding your goals to **"I won't always know where I'm going, but I can always know whether I'm going in the right direction."** Throughout Turing and your job search, come back to your compass to help you understand if your actions are aligned with what's important to you in your new career. When they are, you are absolutely on the right track!
 
@@ -51,17 +51,17 @@ Your social identity is a combination of three broad components:
 
 Even though our social identities could cause us to stick with people who are most like us, by sharing our social identities, we begin to see the ways in which our social identities overlap with people who on the surface seem unlike us. Understanding our social identities allows us to identify the ways in which we already feel like we're a part of the tech industry, identify the ways we don't yet feel that we're a part of the tech industry, and begin to build bridges to incorporate the latter even more.
 
-The [second journal prompt](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-2) for this week asks you to create your social identity map and reflect on how you bring your identity to the tech industry. 
+The [second journal prompt](/module_one/mod1_career_journal_prompts#week-2) for this week asks you to create your social identity map and reflect on how you bring your identity to the tech industry.
 
 #### Values Mapping
-When we discuss values, we're talking about: 
+When we discuss values, we're talking about:
 
 * An enduring belief that a specific mode of conduct or end-state of existence is preferable over others.
 * A principle, standard, or quality considered worthwhile or desirable.
 * What drives our behavior and are directly related to job satisfaction and fulfillment.
 * We value some things more than others and these priorities affect the choices we make in life.
 
-In order to map your values, it's helpful to consider which are most important to you and show up in your life always compared to values that show up in only specific contexts as well as values that you don't hold. Your [third journal prompt this week](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-2) asks you to sort specific values according to different categories: always valued, often valued, sometimes valued, and seldom valued.
+In order to map your values, it's helpful to consider which are most important to you and show up in your life always compared to values that show up in only specific contexts as well as values that you don't hold. Your [third journal prompt this week](/module_one/mod1_career_journal_prompts#week-2) asks you to sort specific values according to different categories: always valued, often valued, sometimes valued, and seldom valued.
 
 #### Workview & Lifeview
 When we say workview, we're talking about what work is and what it means to you. This means summarizing what good, worthwhile work means to you, not about the work you want to do -- this isn't a job description. This is about *why* work matters to you.
@@ -76,9 +76,9 @@ Consider these questions:
 * What does money have to do with it?
 * What do experience, growth, and fulfillment have to do with it?
 
-One could argue that even with all the money and security at a person's fingertips, they would still need work in order to fulfill their purpose. The [positive psychologist Martin Seligman](https://bookshop.org/books/flourish-a-visionary-new-understanding-of-happiness-and-well-being/9781439190760) found that people who can make an explicit connection between their work and something socially meaningful to them are more likely to find satisfaction and are better able to adapt to the inevitable stresses and compromises that come with working. 
+One could argue that even with all the money and security at a person's fingertips, they would still need work in order to fulfill their purpose. The [positive psychologist Martin Seligman](https://bookshop.org/books/flourish-a-visionary-new-understanding-of-happiness-and-well-being/9781439190760) found that people who can make an explicit connection between their work and something socially meaningful to them are more likely to find satisfaction and are better able to adapt to the inevitable stresses and compromises that come with working.
 
-We should also consider our lifeview, which summmarizes what you value in life. This is a summary of your ideas about the world and how it works, and this is why first understanding your social identity and values are so important. 
+We should also consider our lifeview, which summmarizes what you value in life. This is a summary of your ideas about the world and how it works, and this is why first understanding your social identity and values are so important.
 
 Consider these questions:
 
@@ -89,7 +89,7 @@ Consider these questions:
 * What is good and what is evil?
 * What is the role of joy, sorrow, justice, injustice, love, peace, and strife in life?
 
-Your [last journal prompt this week](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-2) asks you to reflect on both your workview and lifeview and consider how they intersect.
+Your [last journal prompt this week](/module_one/mod1_career_journal_prompts#week-2) asks you to reflect on both your workview and lifeview and consider how they intersect.
 
 ### Synthesis
-A success career vision is one that connects the dots between who you are and what you value with the career that you seek out. Aligning your workview and your lifeview will allow you to do just that where you can live a *coherent* life that matches your values and in which you haven't sacrificed your integrity. Any time you feel lost, whether in your job search or in life in general, come back to your compass to get you back on track. 
+A success career vision is one that connects the dots between who you are and what you value with the career that you seek out. Aligning your workview and your lifeview will allow you to do just that where you can live a *coherent* life that matches your values and in which you haven't sacrificed your integrity. Any time you feel lost, whether in your job search or in life in general, come back to your compass to get you back on track.

--- a/module_one/week_3_building_habits.md
+++ b/module_one/week_3_building_habits.md
@@ -15,7 +15,7 @@ Ideas here come from the book [Atomic Habits by James Clear](https://bookshop.or
 * Develop awareness of your current habits
 * Create an implementation intention to build a new habit
 
-### [This Week's Career Journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-3)
+### [This Week's Career Journal](/module_one/mod1_career_journal_prompts#week-3)
 * Identifying habits of a software developer
 * Working on the 1st Law of Behavior Change: Make it Obvious
 * Set Implementation Intentions
@@ -36,7 +36,7 @@ When we say that our identities inform our habits, we mean:
 * Cultivating new behavior (habits) means cultivating new parts of our identities
 * Changing unhelpful/unproductive behavior (habits) means letting go of parts of our identities
 
-Consider the habits you utilize currently. Which are you proud of? What do they say about you? 
+Consider the habits you utilize currently. Which are you proud of? What do they say about you?
 
 Conversely, are there any habits you have that don't reflect the person you want to be? Do you want to break them or replace them with better habits?
 
@@ -65,14 +65,14 @@ Goals are restrictive and conditional:
 
 It's important to start by redesigning your goal. It's not to learn to code; it's to **become** a software a developer. And in order to that, you have to develop ongoing successful processes.
 
-**Do Now:** The first 2 prompts in [this week's career journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/mod1_career_journal_prompts.md#week-3) asks you to consider what the traits and behaviors of a good software developer are.
+**Do Now:** The first 2 prompts in [this week's career journal](/module_one/mod1_career_journal_prompts#week-3) asks you to consider what the traits and behaviors of a good software developer are.
 
 ### Redesign the Systems: Utilize the Habit Loop
 Now, if your goal is to become a software developer, what steps should you take to reach that goal and embody that new identity?
 
 Start with designing a system that can achieve that goal. We'll look here at Clear's Habit Loop:
 
-![Habit Loop](https://github.com/turingschool/career-development-curriculum-site/blob/master/images/habit-loop.png)
+![Habit Loop](/images/habit-loop.png)
 
 This outlines how habits work:
 
@@ -120,13 +120,13 @@ For breaking an ineffective habit, the inverse of the laws applies:
 
 ### Putting the 1st Law into Practice: Build Self-Awareness
 In order to make your habits obvious, you have to start by observing what you do already. What behaviors are effective for becoming the person you want to be?
-Decide if your behaviors align with what you discussed are effective habits for software developers. 
+Decide if your behaviors align with what you discussed are effective habits for software developers.
 
 Then apply some strategies:
 
 * Create an implementation intention
   * Tie the new habit to time and location
-  * “I will [BEHAVIOR] at [TIME] in [LOCATION].” 
+  * “I will [BEHAVIOR] at [TIME] in [LOCATION].”
   * Example: “I will meditate for 1 minute at 7am in my kitchen.”
 
 * Stack the new habit onto a current habit:
@@ -136,4 +136,4 @@ Then apply some strategies:
 
 * Design your environment for success. If you want to make something happen, how can your surroundings or available resources optimize your chances of doing it?
 
-The rest of the journal prompts for this week ask you to put these strategies into place. 
+The rest of the journal prompts for this week ask you to put these strategies into place.

--- a/module_three/cover_letters_overview.md
+++ b/module_three/cover_letters_overview.md
@@ -11,7 +11,7 @@ There are facilitator notes throughout this markdown to divide up responsibiliti
 
 ### Before the Session
 
-Facilitator #1 should select a job posting ahead of time that you'll use to demonstrate writing a cover letter for in the session. Use sites from the [Job Search Strategies](job_search_strategies.md) lesson to help you.
+Facilitator #1 should select a job posting ahead of time that you'll use to demonstrate writing a cover letter for in the session. Use sites from the [Job Search Strategies](job_search_strategies) lesson to help you.
 
 ### Session Structure
 
@@ -173,7 +173,7 @@ Bonus:
 * Interested in a specific company? Use their tools or libraries in your projects at Turing! Mention this in your cover letter
 
 Need help?
-* To ensure you're hitting the right points, you can use this [Cover Letter Checklist](cover_letter_checklist.md)
+* To ensure you're hitting the right points, you can use this [Cover Letter Checklist](cover_letter_checklist)
 
 **Slide #15:**
 
@@ -243,5 +243,5 @@ Using a position you've added to Huntr, work on a cover letter today using the p
 Reminder about deliverables:
 
 * Cover letter draft for a real position due week 1 of Mod 4
-  * Reminder you can find job postings from [the sites listed here](job_search_strategies.md). Remember to note any research you need to do and add it to your Huntr boards.
+  * Reminder you can find job postings from [the sites listed here](job_search_strategies). Remember to note any research you need to do and add it to your Huntr boards.
 * Turing alumni portfolio due Monday of week 6 at 9am

--- a/module_three/index.md
+++ b/module_three/index.md
@@ -28,22 +28,23 @@ At the end of Module 3, students will have:
 
 ### Weekly Topics
 
-* Week 1: [Professional Storytelling II: Resumes & Portfolios](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_1_resumes_and_portfolios.md) 
-* Week 2: [The Application Process](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_2_application_process.md)
-* Week 3: [Outreach & Networking II](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_3_outreach_networking_ii.md)
-* Week 4: [Interview Prep](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_4_interview_prep.md)
-* Week 5: [Refining Your Strategy](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_5_refining_your_strategy.md)
+* Week 1: [Professional Storytelling II: Resumes & Portfolios](/module_three/week_1_resumes_and_portfolios)
+* Week 1: [Professional Storytelling II: Resumes & Portfolios](/module_three/week_1_resumes_and_portfolios)
+* Week 2: [The Application Process](/module_three/week_2_application_process)
+* Week 3: [Outreach & Networking II](/module_three/week_3_outreach_networking_ii)
+* Week 4: [Interview Prep](/module_three/week_4_interview_prep)
+* Week 5: [Refining Your Strategy](/module_three/week_5_refining_your_strategy)
 
 ### Career Journal
-Students will engage in self-reflection and ideation in their career journals every week during a module. 
+Students will engage in self-reflection and ideation in their career journals every week during a module.
 
 **What is a career journal?** The journal will help guide you through the process of discovering who you are as a new developer and how that translates into your career goals.  It’s a way to check in with yourself through self-reflection, prompts, and questions, organize your targeted job search, and remember who you met as you build a professional network.   
-* **Make it your own.** Add questions and areas to reflect on each week. Just don’t forget to share all of your successes and achievements along the way! 
-* **Ongoing progress checks.** Throughout each module, you'll respond to the other prompts and update your progress in your document during professional development workshops and set aside work time. 
-* **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation. 
+* **Make it your own.** Add questions and areas to reflect on each week. Just don’t forget to share all of your successes and achievements along the way!
+* **Ongoing progress checks.** Throughout each module, you'll respond to the other prompts and update your progress in your document during professional development workshops and set aside work time.
+* **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation.
 
 #### Set Up
-Students will create their career journals in Mod 0 and submit them as part of their career development prework. [Here is the Module 3 set of career journal prompts.](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md)
+Students will create their career journals in Mod 0 and submit them as part of their career development prework. [Here is the Module 3 set of career journal prompts.](/module_three/mod3_career_journal_prompts)
 
 ### Repeating the Module
-For students repeating Module 3, they are not required to attend workshops again unless they would like to. They should continue to further their career development goals throughout the module, [following these guidelines and prompts for their career journals](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/m3_repeat_plan.md). The Career Development team will check in with repeating students to provide guidance and answer questions. 
+For students repeating Module 3, they are not required to attend workshops again unless they would like to. They should continue to further their career development goals throughout the module, [following these guidelines and prompts for their career journals](/module_three/m3_repeat_plan). The Career Development team will check in with repeating students to provide guidance and answer questions.

--- a/module_three/m3_repeat_plan.md
+++ b/module_three/m3_repeat_plan.md
@@ -5,7 +5,7 @@ title: PD Plan for Repeating Module 3
 
 # PD Plan for Repeating Module 3
 
-Repeating the module is an opportunity to not only solidify technical skills but also take advantage of extra time to work on your professional development and take concrete steps for your job search. 
+Repeating the module is an opportunity to not only solidify technical skills but also take advantage of extra time to work on your professional development and take concrete steps for your job search.
 
 Reminder that in Mod 3, we covered the topics of:
 
@@ -22,11 +22,11 @@ Here's the breakdown of expectations for repeating the module:
 ### Sessions
 You are **not** required to attend any of the professional development sessions you have attended previously. If you choose to attend any sessions, please plan to fully participate in activities, including breakout group discussions. Reminder of the weekly sessions:
 
-* Week 1: [Professional Storytelling II: Resumes & Portfolios](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_1_resumes_and_portfolios.md) 
-* Week 2: [The Application Process](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_2_application_process.md)
-* Week 3: [Outreach & Networking II](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_3_outreach_networking_ii.md)
-* Week 4: [Interview Prep](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_4_interview_prep.md)
-* Week 5: [Refining Your Strategy](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_5_refining_your_strategy.md)
+* Week 1: [Professional Storytelling II: Resumes & Portfolios](/module_three/week_1_resumes_and_portfolios) 
+* Week 2: [The Application Process](/module_three/week_2_application_process)
+* Week 3: [Outreach & Networking II](/module_three/week_3_outreach_networking_ii)
+* Week 4: [Interview Prep](/module_three/week_4_interview_prep)
+* Week 5: [Refining Your Strategy](/module_three/week_5_refining_your_strategy)
 
 ### Career Journal
 1. Please create a new section of your career journal and title it "Mod 3 Repeat Journal Reflections."
@@ -42,17 +42,17 @@ You are **not** required to attend any of the professional development sessions 
 
 3. Please copy and paste these prompts into your career journal:
 
-* Week 1: 
+* Week 1:
   * Reflections from last mod (what did I do well? Where can I improve?):
   * Goal(s) for the module:
   * Habit to put into place this week:
-  
+
 * Week 2:
   * Reflections on week 1 (what went well? What would you like to do better? What do you need help with?):
   * Progress on your goal(s):
   * Progress on your habit(s):
   * New ideas or changes to put into place this week:
-  
+
 * Week 3:
   * Reflections on week 2 (what went well? What would you like to do better? What do you need help with?):
   * Progress on your goal(s):
@@ -74,4 +74,4 @@ You are **not** required to attend any of the professional development sessions 
 
 **You are expected to be reflecting and responding to these weekly prompts every week during the module in your PD work time. If you have any questions about these expectations, please reach out to Allison.**
 
-Reminder that Allison is available for professional coaching. If you'd like to sign up for a session, please fill out this [request form](https://forms.gle/g84XjDuwLaBidDga9). 
+Reminder that Allison is available for professional coaching. If you'd like to sign up for a session, please fill out this [request form](https://forms.gle/g84XjDuwLaBidDga9).

--- a/module_three/mod3_career_journal_prompts.md
+++ b/module_three/mod3_career_journal_prompts.md
@@ -11,7 +11,7 @@ title: Mod 3 Career Journal Prompts
 * [Week 5 Prompts](#week-5)
 
 ### Directions
-Copy these prompts into your career journal document to complete throughout Mod 3. 
+Copy these prompts into your career journal document to complete throughout Mod 3.
 
 ### Mod 3 Week 1: Professional Storytelling II: Resumes & Portfolios <a name="week-1"></a>
 
@@ -19,7 +19,7 @@ Copy these prompts into your career journal document to complete throughout Mod 
 
 2. Build your resume
 * What will you emphasize in your resume that directly relates to your targeted industries?
-* Pick a template from those listed in the Templates section [here](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/resume_resources.md)
+* Pick a template from those listed in the Templates section [here](/resources/resume_resources)
 * Order your content in this way:
    * Header (Name + Software Developer OR Back End Engineer OR Front End Engineer, etc.)
    * Contact info
@@ -28,10 +28,10 @@ Copy these prompts into your career journal document to complete throughout Mod 
    * Projects
    * Experience
    * Education
-* Check out other resources [here](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/resume_resources.md) including the Resume Checklist
-* Link to your resume or include a screenshot here: 
+* Check out other resources [here](/resources/resume_resources) including the Resume Checklist
+* Link to your resume or include a screenshot here:
 
-3. Upload your resume to CV Compiler by following these steps: 
+3. Upload your resume to CV Compiler by following these steps:
 * Go to [https://cvcompiler.com/students/turingschool](https://cvcompiler.com/students/turingschool)
 * Click on "Improve Your Student Resume"
 * Authorize it with either LinkedIn or GitHub
@@ -47,10 +47,10 @@ Copy these prompts into your career journal document to complete throughout Mod 
     * What do you want this portfolio to say about you?
     * How will you continue to add to this to portray your story and showcase the kind of work that demonstrates your brand?\\
 
-5. Ian's workshop this week is designed to help you break down your interest in specific industries even further by exploring their tech stacks to decide if you want to utilize any of their tools in upcoming projects. Make a copy of his [template here](https://docs.google.com/spreadsheets/d/1Ncn2w6l3SaXOM71ZHcBPutxCoFOhHNlDa56Xuzz0SHs/edit?usp=sharing) and post a link to your copy here to show what research you've completed. You can also link this research to your Huntr board. 
+5. Ian's workshop this week is designed to help you break down your interest in specific industries even further by exploring their tech stacks to decide if you want to utilize any of their tools in upcoming projects. Make a copy of his [template here](https://docs.google.com/spreadsheets/d/1Ncn2w6l3SaXOM71ZHcBPutxCoFOhHNlDa56Xuzz0SHs/edit?usp=sharing) and post a link to your copy here to show what research you've completed. You can also link this research to your Huntr board.
 
 ### Mod 3 Week 2: The Application Process  <a name="week-2"></a>
-1. Find a position or use a position you've put on your Huntr board and write a cover letter for that position in a Google doc or gist. Reference these [cover letter resources](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/cover_letter_resources.md) as well as [the session](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/week_2_application_process.md) to complete your cover letter. 
+1. Find a position or use a position you've put on your Huntr board and write a cover letter for that position in a Google doc or gist. Reference these [cover letter resources](/resources/cover_letter_resources) as well as [the session](/module_three/week_2_application_process) to complete your cover letter. 
 * Post the link to your cover letter here
 
 2. Review your cover letter with a peer some time this week. What feedback did your partner give you? What next steps will you take to make your cover letter even stronger?
@@ -59,7 +59,7 @@ Copy these prompts into your career journal document to complete throughout Mod 
 
 ### Mod 3 Week 3: Outreach & Networking II <a name="week-3"></a>
 Outreach & Networking Plan:  
-* What company are you exploring this week? Who will you contact from that company? Why that person? How will you contact them? How will you follow up? 
+* What company are you exploring this week? Who will you contact from that company? Why that person? How will you contact them? How will you follow up?
 
 Execute your plan:
 * Reach out to your contact THIS WEEK. If possible, reach out to more than one person OR find a meetup to attend also. What happened? What did you learn about the company? What other next steps should you take for pursuing this company? Be sure to update this in Huntr.
@@ -69,24 +69,23 @@ Prepare for Job Shadow: AEIOU
 * Activities: what questions do you have about the activities that a software developer does on a daily basis?  
 * Environment: what questions do you have about the overall environment and culture of this workplace?
 * Interactions: what questions do you have about the team at this company? What do you hope to see in your interactions during the shadow?
-* Objects: what questions do you have about the code or the product? 
-* Users: what questions do you have about how the company interacts with their users? 
+* Objects: what questions do you have about the code or the product?
+* Users: what questions do you have about how the company interacts with their users?
 
 After the Job Shadow, reflect on the same questions; what are your takeaways from the shadow? Ho
 * Activities: what was engaging to the person/people you shadowed?
 * Environment: what did you notice about how they talked about the culture and environment of this company?
 * Interactions: what did you notice about your interactions with this person/people?
 * Objects: what did you learn about their approach to code and/or product development?
-* Users: what did you learn about their approach to their users? 
+* Users: what did you learn about their approach to their users?
 * What are your main takeaways from the shadow? How will you use this information to help you with your job search strategy?
 
 Interview Prep:
 * Pick a successful project and write about it with the STAR method:
 * Write about a time you failed and what you learned from that experience:
-* Write about how you've approached working with a team using a specific example: 
+* Write about how you've approached working with a team using a specific example:
 * What other stories will you prepare to share?
 * Do some research into your top companies' tech stacks; what do you already know? What can you compare to your own learning? What do you need to learn more about?
-* Using this [interview prep resource doc](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/interview_prep_resources.md), pick out at least 3 resources you will use to prepare for interviews as well as 3 behavioral questions you could practice:
+* Using this [interview prep resource doc](/resources/interview_prep_resources), pick out at least 3 resources you will use to prepare for interviews as well as 3 behavioral questions you could practice:
 
 ### Mod 3 Week 5: Refining Your Stratey  <a name="week-5"></a>
- 

--- a/module_three/professional_storytelling_iii.md
+++ b/module_three/professional_storytelling_iii.md
@@ -50,8 +50,8 @@ We'll focus on:
 Some resources for you:
 
 * Join #job-hunt
-* [Interview Prep Resources](interview_prep_resources.md)
-* [Job Search Care Package](/module-5/job_search_care_package.md)
+* [Interview Prep Resources](interview_prep_resources)
+* [Job Search Care Package](/module-5/job_search_care_package)
 
 **Slide #4:**
 
@@ -221,7 +221,7 @@ As a junior developer, your resume might look very different from its previous f
 
 #### Content Inclusion - Follow this order
 
-Use this [checklist when creating your resume](resume_review_checklist.md)
+Use this [checklist when creating your resume](resume_review_checklist)
 
 * **Header:**
 	* Name, phone number, email, GitHub, LinkedIn, personal site (These should all be linked text, not the long URL strings)

--- a/module_three/week_1_resumes_and_portfolios.md
+++ b/module_three/week_1_resumes_and_portfolios.md
@@ -13,7 +13,7 @@ subheading: Resumes & Portfolios
 * Utilize your job search strategy to customize your resume
 * Utilize your job search strategy to customize your alumni portfolio
 
-### [This Week's Career Journal Prompts](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-1)
+### [This Week's Career Journal Prompts](/module_three/mod3_career_journal_prompts#week-1)
 * Refine your career vision and industry list
 * Build your resume
 * Build your Turing portfolio
@@ -22,10 +22,10 @@ subheading: Resumes & Portfolios
 ### Overview
 Last mod, we spent time defining and revising your career vision based on the values and goals you have for this career. We’ll start here again this module because everything we do in the job search needs to tie back to that career vision. Remember, this is your **compass** -- your vision gives you direction on where to go in your job search, and your strategy should be based on that.
 
-This week's [first prompt in your career journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-1) asks you to reflect on this vision and make sure it's still aligned with what you want. 
+This week's [first prompt in your career journal](/module_three/mod3_career_journal_prompts#week-1) asks you to reflect on this vision and make sure it's still aligned with what you want. 
 
 ### Resumes
-It's important to know what your career vision is and the strategy you're utilizing to put it into place because these are the foundations for your resume. 
+It's important to know what your career vision is and the strategy you're utilizing to put it into place because these are the foundations for your resume.
 
 * Common misconception: Your resume should be one-size-fits-all
 * Reframe: Your resume should be a direct reflection of the strategy you’re using in the job search
@@ -38,7 +38,7 @@ Since you are a software developer now, your software projects are an essential 
 * Open Source projects
 * Etc.
 
-You should include links to your repos and deployed apps. Note: for group projects that exist on your partner's GitHub, make sure you fork your own version and include that link instead. 
+You should include links to your repos and deployed apps. Note: for group projects that exist on your partner's GitHub, make sure you fork your own version and include that link instead.
 
 Your descriptions for your projects should tell a reader what the project is and what is does in as few words as possible. The rest of the description should be about accomplishments from that project and value added. What was your role in the project? What specific goals did you meet?
 
@@ -49,7 +49,7 @@ Reminder that you should **always** customize your resume to the position for wh
 2. Showcasing specific projects
 3. Highlight transferable skills
 
-We recommend using a summary statement on your new resume so that you can: 
+We recommend using a summary statement on your new resume so that you can:
 
 1. Describe why you've made a career change
 2. Make a connection between the company you're applying to and the work you do/want to do
@@ -68,13 +68,13 @@ When building your resume, make sure to keep this checklist handy as well:
 * Don't include a headshot -- it will take up valuable space and it's not a norm in this industry.
 * Your resume should only be 1 page. Employers will not read past that 1 page.
 * There are a lot of templates you can use, but be conservative with colors. Consider readability and printability.
-* Using a [template like those listed here](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/resume_resources.md) will ensure your resume passes an ATS system (applicant tracking system)
-* Don't list your special interests or hobbies. They don't belong on a technical resume. Instead, you can put them on your LinkedIn profile. 
+* Using a [template like those listed here](/resources/resume_resources) will ensure your resume passes an ATS system (applicant tracking system)
+* Don't list your special interests or hobbies. They don't belong on a technical resume. Instead, you can put them on your LinkedIn profile.
 
 ### What to Do
-This week is focused on building your working resume. These [steps are outlined in your second and third prompts in this week's career journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-1):
+This week is focused on building your working resume. These [steps are outlined in your second and third prompts in this week's career journal](/module_three/mod3_career_journal_prompts#week-1):
 
-* Build your resume using [these templates and checklist](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/resume_resources.md)
+* Build your resume using [these templates and checklist](/resources/resume_resources)
 * Upload it to CV Compiler, which is an ATS system we partner with that will provide you with feedback on your resume (instructions in the career journal).
 * Update your resume using that feedback
 
@@ -88,13 +88,13 @@ Review these alumni resumes:
 * [Andrew James](https://github.com/turingschool/career-development-curriculum/blob/master/files/Andrew%20James%20Resume.pdf)
 * [Alex Tideman](https://alumni.turing.io/sites/default/files/resumes/alex_tideman.pdf)
 
-Consider: 
+Consider:
 
 * What is your first impression of this candidate?
-* What do you know about this candidate's technical abilities? 
+* What do you know about this candidate's technical abilities?
 * What questions do you have about this candidate?
 * Would you choose to interview this person based on their resume? Why or why not?
-* If you decide to interview them, what follow-up questions would you ask? 
+* If you decide to interview them, what follow-up questions would you ask?
 
 ### Turing Alumni Portfolios
 Turing provides you with a space to build a portfolio on our website at [alumni.turing.io](https://alumni.turing.io/). These portfolios are how we showcase our job seeking graduates and soon-to-be graduates! We share these directly with employers, but employers also regularly come to our site to look for candidates.
@@ -119,7 +119,7 @@ Unfortunately, this site was built by a different company and contains a lot of 
 * Use Safari
 * Double check all fields when trying to save
 * Select any cohort (cohort does not matter)
-* Do not copy and paste information 
+* Do not copy and paste information
   * It will not paste in correctly
 * GitHub ID doesn't matter; leave it blank
 

--- a/module_three/week_2_application_process.md
+++ b/module_three/week_2_application_process.md
@@ -13,13 +13,13 @@ title: The Application Process
 * Analyze a job posting in order to understand how approach a cover letter for it
 * Understand and apply best practices for writing cover letters
 
-### [This Week's Career Journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md#week-2)
+### [This Week's Career Journal](/module_three/mod3_career_journal_prompts#week-2)
 * Find a position to write a cover letter for
 * Participate in peer review on cover letter
 * Consider how to customize your resume for the position
 
 ### Overview
-Last mod, we discussed [lots of tools for building your job search strategy](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_3_job_search_strategies.md), such as searching by:
+Last mod, we discussed [lots of tools for building your job search strategy](/module_two/week_3_job_search_strategies), such as searching by:
 
 * Specific companies
 * Culture
@@ -28,13 +28,13 @@ Last mod, we discussed [lots of tools for building your job search strategy](htt
 * Job listings
 * Recruiter sites
 
-You can find all this information synthesized here in the [Resources page on Finding Opportunities](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/finding_opportunities.md).
+You can find all this information synthesized here in the [Resources page on Finding Opportunities](/resources/finding_opportunities).
 
 We also looked at this chart to understand the components of the job search process:
 
-![Job Search Strategy Chart](https://github.com/turingschool/career-development-curriculum-site/blob/master/images/Job%20Search%20Strategy%20Chart.png)
+![Job Search Strategy Chart](/images/Job%20Search%20Strategy%20Chart.png)
 
-Today, we're going to spend more time diving into the 4th step on what goes into the actual application. 
+Today, we're going to spend more time diving into the 4th step on what goes into the actual application.
 
 ### Application Process
 The actual application refers to 3 things:
@@ -48,27 +48,27 @@ However, it’s important to note that application materials can only get you so
 That said, your application materials do matter! Common mistakes we see from job seekers include not thoroughly reading the job posting and not customizing resumes and/or cover letters. So, once again, you should **always** customize your application materials. Not doing so hurts your chances at the company. Let's take a look at these steps more closely.
 
 #### Step #1: Analyze the Job Posting
-In any job posting, pay attention to the keywords that are used. Words that are used more than once are very important, and these are the words you want to make sure to incorporate into your resume and cover letter. Highlight the words and phrases in the posting that speak to specific skills or experience that you have as well as specific skills or experience that are similar to what you have done in the past. 
+In any job posting, pay attention to the keywords that are used. Words that are used more than once are very important, and these are the words you want to make sure to incorporate into your resume and cover letter. Highlight the words and phrases in the posting that speak to specific skills or experience that you have as well as specific skills or experience that are similar to what you have done in the past.
 
 * What projects have you done that showcase these skills?
 * What transferable skills do you have from previous experiences?
-* What new skills can you start to learn? 
+* What new skills can you start to learn?
 
 #### Step #2: Customize Your Resume
-The skills you have listed on your resume should match the skills that the company is looking for based on the job posting. Note: that doesn't mean you should lie -- ever. If you don't have a skill, don't put it on your resume. Your projects and experience descriptions should also demonstrate what the company is looking for. Reword these descriptions to showcase the skills and mindsets that the company is looking for. 
+The skills you have listed on your resume should match the skills that the company is looking for based on the job posting. Note: that doesn't mean you should lie -- ever. If you don't have a skill, don't put it on your resume. Your projects and experience descriptions should also demonstrate what the company is looking for. Reword these descriptions to showcase the skills and mindsets that the company is looking for.
 
 [JobScan](https://www.jobscan.co/) is a great tool that allows you to upload a job posting and your resume to see how they match up to optimize your chances.
 
 #### Step #3: Cover Letters
-Cover letters can seem daunting, but they don't have to be. It's important to understand their importance in order to know how to write them well. A common misconception is that a cover letter should be all about you as the candidate. However, your cover letter is actually a space to demonstrate your understanding of the company. Another common misconception is that a cover letter should regurgitate everything on your resume. It should actually complement your resume; your resume is a space to tell about you, your cover letter allows you to *show* much more. 
+Cover letters can seem daunting, but they don't have to be. It's important to understand their importance in order to know how to write them well. A common misconception is that a cover letter should be all about you as the candidate. However, your cover letter is actually a space to demonstrate your understanding of the company. Another common misconception is that a cover letter should regurgitate everything on your resume. It should actually complement your resume; your resume is a space to tell about you, your cover letter allows you to *show* much more.
 
-Start with this frame in your mind -- the cover letter is a love letter to the company. How? Again, start by demonstrating your understanding of the company. 
+Start with this frame in your mind -- the cover letter is a love letter to the company. How? Again, start by demonstrating your understanding of the company.
 
 * What research have you done?
 * Who from the company have you talked to?
 * Go back to the job posting -- what are they looking for? What needs do they have based on this posting?
 * What problem is this company trying to solve?
-* What is exciting about this company? 
+* What is exciting about this company?
 
 Then, talk about yourself, but remember -- this still isn't really about you. Talk about yourself in relation to the company. First, provide an introductory hook. Show what you know about the company and *why* you're interested in the position. Then, show why you're qualified for the job. A great way to template out your story is by a quick summary: "Merging my background in X and Y, I now help [industry] improve [these outcomes]." You can also break your story into parts:
 
@@ -97,14 +97,14 @@ If you find yourself with:
 #### Cover Letter Activity
 Look through the cover letters of alumni listed here and consider:
 
-* [April Dagonese](https://github.com/turingschool/career-development-curriculum-site/blob/master/files/April%20Cover%20Letter.pdf)
-* [Abdulla Qudrat](https://github.com/turingschool/career-development-curriculum-site/blob/master/files/Abdulla_Blinker%20Cover%20Letter.pdf)
-* [Tommasina Miller](https://github.com/turingschool/career-development-curriculum-site/blob/master/files/Example%20Cover%20Letter.pdf)
-* [Vinton Te'o](https://github.com/turingschool/career-development-curriculum-site/blob/master/files/Vinton%20Cover%20Letter.pdf)
+* [April Dagonese](/files/April%20Cover%20Letter.pdf)
+* [Abdulla Qudrat](/files/Abdulla_Blinker%20Cover%20Letter.pdf)
+* [Tommasina Miller](/files/Example%20Cover%20Letter.pdf)
+* [Vinton Te'o](/files/Vinton%20Cover%20Letter.pdf)
 
 * What do you notice about these cover letters?
 * What is effective? What value could they bring to the company? How do you know?
 * What could be changed to make the letter more effective?
 
 ### Synthesis
-As you work on your cover letter this week, here are [additional resources](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/cover_letter_resources.md) to help you. 
+As you work on your cover letter this week, here are [additional resources](/resources/cover_letter_resources) to help you. 

--- a/module_three/week_4_interview_prep.md
+++ b/module_three/week_4_interview_prep.md
@@ -11,16 +11,16 @@ subheading: Putting It All Together
 
 ### Learning Goals
 * Understand how to answer interview questions using the STAR method
-* 
+*
 
-### [This Week's Career Journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_three/mod3_career_journal_prompts.md)
-* 
+### [This Week's Career Journal](/module_three/mod3_career_journal_prompts)
+*
 
 
 ### Connecting it all Together
 We've been focusing on:
 
-* 
+*
 
 
 ### Opening
@@ -114,5 +114,3 @@ Get into groups of 3-4 for more practice on these questions. You could also choo
 * Kind
 
 ### Closing
-
-

--- a/module_two/index.md
+++ b/module_two/index.md
@@ -22,7 +22,7 @@ At the end of Module 2, students will have:
 * An outlined strategy for their job search
 * An understanding of best practices for outreach and networking
 
-In Module 3, they will expand on this learning by focusing on executing their strategies. 
+In Module 3, they will expand on this learning by focusing on executing their strategies.
 
 ### Weekly Topics
 
@@ -33,15 +33,15 @@ In Module 3, they will expand on this learning by focusing on executing their st
 * Week 5: [Outreach & Networking I](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_5_outreach_networking_i.md)
 
 ### Career Journal
-Students will engage in self-reflection and ideation in their career journals every week during a module. 
+Students will engage in self-reflection and ideation in their career journals every week during a module.
 
 **What is a career journal?** The journal will help guide you through the process of discovering who you are as a new developer and how that translates into your career goals.  It’s a way to check in with yourself through self-reflection, prompts, and questions, organize your targeted job search, and remember who you met as you build a professional network.   
-* **Make it your own.** Add questions and areas to reflect on each week. Just don’t forget to share all of your successes and achievements along the way! 
-* **Ongoing progress checks.** Throughout each module, you'll respond to the other prompts and update your progress in your document during professional development workshops and set aside work time. 
-* **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation. 
+* **Make it your own.** Add questions and areas to reflect on each week. Just don’t forget to share all of your successes and achievements along the way!
+* **Ongoing progress checks.** Throughout each module, you'll respond to the other prompts and update your progress in your document during professional development workshops and set aside work time.
+* **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation.
 
 #### Set Up
 Students will create their career journals in Mod 0 and submit them as part of their career development prework. [Here is the Module 2 set of career journal prompts.](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md)
 
 ### Repeating the Module
-For students repeating Module 2, they are not required to attend workshops again unless they would like to. They should continue to further their career development goals throughout the module, [following these guidelines and prompts for their career journals](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/m2_pd_repeat_plan.md). The Career Development team will check in with repeating students to provide guidance and answer questions. 
+For students repeating Module 2, they are not required to attend workshops again unless they would like to. They should continue to further their career development goals throughout the module, [following these guidelines and prompts for their career journals](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/m2_pd_repeat_plan.md). The Career Development team will check in with repeating students to provide guidance and answer questions.

--- a/module_two/index.md
+++ b/module_two/index.md
@@ -26,11 +26,11 @@ In Module 3, they will expand on this learning by focusing on executing their st
 
 ### Weekly Topics
 
-* Week 1: [Building Habits to Become a Software Developer, Part II](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_1_habits_part_ii.md)
-* Week 2: [Professional Storytelling & Branding](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_2_professional_storytelling_branding.md)
-* Week 3: [Job Search Strategies](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_3_job_search_strategies.md)
-* Week 4: [Building Habits to Become a Software Developer, Part III](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_4_habits_part_iii.md)
-* Week 5: [Outreach & Networking I](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_5_outreach_networking_i.md)
+* Week 1: [Building Habits to Become a Software Developer, Part II](/module_two/week_1_habits_part_ii)
+* Week 2: [Professional Storytelling & Branding](/module_two/week_2_professional_storytelling_branding)
+* Week 3: [Job Search Strategies](/module_two/week_3_job_search_strategies)
+* Week 4: [Building Habits to Become a Software Developer, Part III](/module_two/week_4_habits_part_iii)
+* Week 5: [Outreach & Networking I](/module_two/week_5_outreach_networking_i)
 
 ### Career Journal
 Students will engage in self-reflection and ideation in their career journals every week during a module.
@@ -41,7 +41,7 @@ Students will engage in self-reflection and ideation in their career journals ev
 * **Module Expectations.** A completed career journal is required for successfully passing each module. The career development team will be assessing your progress throughout the module, and you will submit it for final review in week 6. You will also include highlights from your progress in your end of module portfolio presentation.
 
 #### Set Up
-Students will create their career journals in Mod 0 and submit them as part of their career development prework. [Here is the Module 2 set of career journal prompts.](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md)
+Students will create their career journals in Mod 0 and submit them as part of their career development prework. [Here is the Module 2 set of career journal prompts.](/module_two/mod2_career_journal_prompts)
 
 ### Repeating the Module
-For students repeating Module 2, they are not required to attend workshops again unless they would like to. They should continue to further their career development goals throughout the module, [following these guidelines and prompts for their career journals](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/m2_pd_repeat_plan.md). The Career Development team will check in with repeating students to provide guidance and answer questions.
+For students repeating Module 2, they are not required to attend workshops again unless they would like to. They should continue to further their career development goals throughout the module, [following these guidelines and prompts for their career journals](/module_two/m2_pd_repeat_plan). The Career Development team will check in with repeating students to provide guidance and answer questions.

--- a/module_two/m2_pd_repeat_plan.md
+++ b/module_two/m2_pd_repeat_plan.md
@@ -5,7 +5,7 @@ title: PD Plan for Repeating Module 2
 
 # PD Plan for Repeating Module 2
 
-Repeating the module is an opportunity to not only solidify technical skills but also take advantage of extra time to work on your professional development and take concrete steps for your job search. 
+Repeating the module is an opportunity to not only solidify technical skills but also take advantage of extra time to work on your professional development and take concrete steps for your job search.
 
 Reminder that in Mod 2, we covered the topics of:
 
@@ -21,14 +21,14 @@ Here's the breakdown of expectations for repeating the module:
 ### Sessions
 This module, you are required to attend:
 
-* Week 1: [Building Habits to Become a Software Developer, Part II](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_1_habits_part_ii.md)
-* Week 4: [Building Habits to Become a Software Developer, Part III](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_4_habits_part_iii.md)
+* Week 1: [Building Habits to Become a Software Developer, Part II](/module_two/week_1_habits_part_ii)
+* Week 4: [Building Habits to Become a Software Developer, Part III](/module_two/week_4_habits_part_iii)
 
 You are **not** required to attend any of the professional development sessions you have attended previously. If you choose to attend any sessions, please plan to fully participate in activities, including breakout group discussions. Reminder of the other weekly sessions:
 
-* Week 2: [Professional Storytelling & Branding](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_2_professional_storytelling_branding.md)
-* Week 3: [Job Search Strategies](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_3_job_search_strategies.md)
-* Week 5: [Outreach & Networking I](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_5_outreach_networking_i.md)
+* Week 2: [Professional Storytelling & Branding](/module_two/week_2_professional_storytelling_branding)
+* Week 3: [Job Search Strategies](/module_two/week_3_job_search_strategies)
+* Week 5: [Outreach & Networking I](/module_two/week_5_outreach_networking_i)
 
 ### Career Journal
 1. Please create a new section of your career journal and title it "Mod 2 Repeat Journal Reflections."
@@ -37,13 +37,13 @@ You are **not** required to attend any of the professional development sessions 
   * Updating your LinkedIn profile
   * Implementing additional outreach with people from the Turing community or the tech community at large
   * Deciding on new strategies for your job search (i.e., refining the industries and companies you're looking at, conducting research on those companies, deciding next steps for outreach, etc.)
-  
+
 3. Please copy and paste these prompts into your career journal:
 
-#### Week 1: [Building Habits to Become an Effective Software Developer, Part II](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_1_habits_part_ii.md)
+#### Week 1: [Building Habits to Become an Effective Software Developer, Part II](/module_two/week_1_habits_part_ii)
 Ideas here are adapted from [Atomic Habits by James Clear](https://bookshop.org/books/atomic-habits-an-easy-proven-way-to-build-good-habits-break-bad-ones/9780735211292)
 
-1. Module 1's PD now includes a sesson on Part I of the habits series. Please read through that [session here](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_3_building_habits.md). Reflect on your habits from last module. What behaviors and activities were helpful for you? What activities and behaviors could be more effective for you? What processes would you like to try differently this module to become more effective at your work and as a software developer? 
+1. Module 1's PD now includes a sesson on Part I of the habits series. Please read through that [session here](/module_one/week_3_building_habits). Reflect on your habits from last module. What behaviors and activities were helpful for you? What activities and behaviors could be more effective for you? What processes would you like to try differently this module to become more effective at your work and as a software developer? 
 
 2. Setting intentions for this module: who do I want to be this module? What specific habits would help me get there? How are those habits tied to the identity of a software developer?
 
@@ -51,38 +51,38 @@ Ideas here are adapted from [Atomic Habits by James Clear](https://bookshop.org/
   * After [CURRENT HABIT], I will [HABIT I NEED TO DO].
   * After [HABIT I NEED], I will [HABIT I WANT TO DO].
 
-4. How to enjoy “hard” habits: Reframe your habits to consider their benefits rather than their drawbacks; name 3 habits that you have to do and explain the benefits of them. How do they further your goals longterm? How will they add to your processes as a successful developer? At the end of the day, how do they add to your life? 
+4. How to enjoy “hard” habits: Reframe your habits to consider their benefits rather than their drawbacks; name 3 habits that you have to do and explain the benefits of them. How do they further your goals longterm? How will they add to your processes as a successful developer? At the end of the day, how do they add to your life?
 
-5. Environment design (optional 5-min. additional reading: [Motivation is Overvalued. Environment Often Matters More](https://jamesclear.com/power-of-environment)): how does your environment set-up currently help you with your habits? How could it be improved to make it easier for you to follow through on your habits? 
+5. Environment design (optional 5-min. additional reading: [Motivation is Overvalued. Environment Often Matters More](https://jamesclear.com/power-of-environment)): how does your environment set-up currently help you with your habits? How could it be improved to make it easier for you to follow through on your habits?
 
-6. “When you start a new habit, it should take less than two minutes to do.” Read this 4-min article on [how to stop procrastinating](https://jamesclear.com/how-to-stop-procrastinating). Apply the 2-minute rule to reframe 2-3 of your habits by scaling them down into the 2-minute version. How does this reframing help you think about shaping your new identity as a software developer? 
-  
-#### Week 2: Goal Reflections 
-  * Name the 1-2 goals you'll work on this mod: 
+6. “When you start a new habit, it should take less than two minutes to do.” Read this 4-min article on [how to stop procrastinating](https://jamesclear.com/how-to-stop-procrastinating). Apply the 2-minute rule to reframe 2-3 of your habits by scaling them down into the 2-minute version. How does this reframing help you think about shaping your new identity as a software developer?
+
+#### Week 2: Goal Reflections
+  * Name the 1-2 goals you'll work on this mod:
   * Reflections on week 1 (what went well? What would you like to do better? What do you need help with?):
   * Progress on your goal(s):
   * Progress on your habit(s):
   * New ideas or changes to put into place this week:
-  
+
 #### Week 3: Goal Reflections
   * Reflections on week 2 (what went well? What would you like to do better? What do you need help with?):
   * Progress on your goal(s):
   * Progress on your habit(s):
   * New ideas or changes to put into place this week:
 
-#### Week 4: [Building Habits to Become an Effective Software Developer, Part III](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/week_4_habits_part_iii.md)
+#### Week 4: [Building Habits to Become an Effective Software Developer, Part III](/module_two/week_4_habits_part_iii)
 Ideas here are adapted from [Atomic Habits by James Clear](https://bookshop.org/books/atomic-habits-an-easy-proven-way-to-build-good-habits-break-bad-ones/9780735211292)
-1. Assess your habits from week 3: how did you spend your time this past week? What was effective in your habits? What could be more effective? What steps will you take to make that happen? 
+1. Assess your habits from week 3: how did you spend your time this past week? What was effective in your habits? What could be more effective? What steps will you take to make that happen?
 
 2. Implement a reiforcement strategy: to make one of your habits more satisfying, what is a reward you can give yourself immediately after completing the habit? How will this reward encourage you to continue completing that habit?
 
 3. "Don't Break the Chain": Use a habit tracker
 * What is a habit that you want to make sure to do *every day*? How could you visually cue yourself to complete it (i.e., moving a paper clip)? How can you visually track it each time you've completed it? Could you automate the tracking? How will you do that?
 * Need help? Check out one of these [habit tracking apps](https://www.lifehack.org/668261/best-habit-tracking-apps)
- 
+
 4. How to get back on track when missing a habit: if you miss a day or two of completing your habit, how will you get yourself going again?
 
-5. Pick an accountability partner (your cohort accountabilibuddy, your mentor, a close friend, etc.) and create a habit contract with them. How often will you check in with each other? How will they hold you accountable? 
+5. Pick an accountability partner (your cohort accountabilibuddy, your mentor, a close friend, etc.) and create a habit contract with them. How often will you check in with each other? How will they hold you accountable?
 
 #### Week 5: Goal Reflections
   * Reflections on week 4 (what went well? What would you like to do better? What do you need help with?):
@@ -93,4 +93,4 @@ Ideas here are adapted from [Atomic Habits by James Clear](https://bookshop.org/
 
 **You are expected to be reflecting and responding to these weekly prompts every week during the module in your PD work time. If you have any questions about these expectations, please reach out to Allison.**
 
-Reminder that Allison is available for professional coaching. If you'd like to sign up for a session, please fill out this [request form](https://forms.gle/g84XjDuwLaBidDga9). 
+Reminder that Allison is available for professional coaching. If you'd like to sign up for a session, please fill out this [request form](https://forms.gle/g84XjDuwLaBidDga9).

--- a/module_two/mod2_career_journal_prompts.md
+++ b/module_two/mod2_career_journal_prompts.md
@@ -17,7 +17,7 @@ Copy these prompts into your career journal document to complete throughout Mod 
 ### Mod 2 Week 1: Building Habits to Become a Software Developer, Part II  <a name="week-1"></a>
 Ideas here are adapted from [Atomic Habits by James Clear](https://bookshop.org/books/atomic-habits-an-easy-proven-way-to-build-good-habits-break-bad-ones/9780735211292)
 
-1. Reflect on your habits from last module. What behaviors and activities were helpful for you? What activities and behaviors could be more effective for you? What processes would you like to try differently this module to become more effective at your work and as a software developer? 
+1. Reflect on your habits from last module. What behaviors and activities were helpful for you? What activities and behaviors could be more effective for you? What processes would you like to try differently this module to become more effective at your work and as a software developer?
 
 2. Setting intentions for this module: who do I want to be this module? What specific habits would help me get there? How are those habits tied to the identity of a software developer?
 
@@ -25,23 +25,23 @@ Ideas here are adapted from [Atomic Habits by James Clear](https://bookshop.org/
   * After [CURRENT HABIT], I will [HABIT I NEED TO DO].
   * After [HABIT I NEED], I will [HABIT I WANT TO DO].
 
-4. How to enjoy “hard” habits: Reframe your habits to consider their benefits rather than their drawbacks; name 3 habits that you have to do and explain the benefits of them. How do they further your goals longterm? How will they add to your processes as a successful developer? At the end of the day, how do they add to your life? 
+4. How to enjoy “hard” habits: Reframe your habits to consider their benefits rather than their drawbacks; name 3 habits that you have to do and explain the benefits of them. How do they further your goals longterm? How will they add to your processes as a successful developer? At the end of the day, how do they add to your life?
 
-5. Environment design (optional 5-min. additional reading: [Motivation is Overvalued. Environment Often Matters More](https://jamesclear.com/power-of-environment)): how does your environment set-up currently help you with your habits? How could it be improved to make it easier for you to follow through on your habits? 
+5. Environment design (optional 5-min. additional reading: [Motivation is Overvalued. Environment Often Matters More](https://jamesclear.com/power-of-environment)): how does your environment set-up currently help you with your habits? How could it be improved to make it easier for you to follow through on your habits?
 
-6. “When you start a new habit, it should take less than two minutes to do.” Read this 4-min article on [how to stop procrastinating](https://jamesclear.com/how-to-stop-procrastinating). Apply the 2-minute rule to reframe 2-3 of your habits by scaling them down into the 2-minute version. How does this reframing help you think about shaping your new identity as a software developer? 
+6. “When you start a new habit, it should take less than two minutes to do.” Read this 4-min article on [how to stop procrastinating](https://jamesclear.com/how-to-stop-procrastinating). Apply the 2-minute rule to reframe 2-3 of your habits by scaling them down into the 2-minute version. How does this reframing help you think about shaping your new identity as a software developer?
 
 ### Mod 2 Week 2: Professional Storytelling & Branding  <a name="week-2"></a>
-1. Assess your habits from week 1: how did you spend your time this past week? What was effective in your habits? What could be more effective? What steps will you take to make that happen? 
+1. Assess your habits from week 1: how did you spend your time this past week? What was effective in your habits? What could be more effective? What steps will you take to make that happen?
 
 2. Write a draft of your professional story here as 1-2 paragraphs. Focus on answering the questions *who are you, why are you here,* and *what's next?* Consider how to talk about your motives and values, the turning points that led to your career change, and what you envision for yourself going forward.
 
-2. Update your LinkedIn profile with the following: updated photo/headshot, headline, summary statement using your story, and Turing added to your experience and education sections. Include a link to your profile here in the journal. Remember the guidelines and tips from the [lesson here](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/professional_storytelling_branding.md). 
+2. Update your LinkedIn profile with the following: updated photo/headshot, headline, summary statement using your story, and Turing added to your experience and education sections. Include a link to your profile here in the journal. Remember the guidelines and tips from the [lesson here](/module_two/professional_storytelling_branding).
 
 3. What other steps will you take this week to update your branding or practice your story?
 
 ### Mod 2 Week 3: Job Search Strategies <a name="week-3"></a>
-Assess your habits from week 2: how did you spend your time this past week? What was effective in your habits? What could be more effective? What steps will you take to make that happen? 
+Assess your habits from week 2: how did you spend your time this past week? What was effective in your habits? What could be more effective? What steps will you take to make that happen?
 
 Reflect on how you’ve spent your time so far at Turing to gauge your engagement and energy:
 * When have you been excited, focused, and enjoyed your work?
@@ -53,7 +53,7 @@ Setting up habits and routines to make time for the job search this module:
 * Block out time on your calendar this week to work on your job search. When will you make this happen? How will you hold yourself accountable to this? What activities will you focus on during this time this week? What outcomes do you hope to reach by the end of this week because of these activities?
 
 Applying wayfinding to using job search resources
-* Go through the resources [listed here](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/finding_opportunities.md) and explore 2-3 tools. List what you looked at here:
+* Go through the resources [listed here](/resources/finding_opportunities) and explore 2-3 tools. List what you looked at here:
 * Apply wayfinding: of what you looked at, what did you discover that aligns with your vision? If it didn't align with your vision, what will you try next?
 * Find a job posting that aligns with your vision. What's the posting? How does it align with what you're looking for? Add it to your Huntr.
 * What next steps will you take to explore that opportunity and find contacts? Add that information to your Huntr card.
@@ -61,39 +61,39 @@ Applying wayfinding to using job search resources
 ### Mod 2 Week 4: Building Habits to Become a Software Developer, Part III  <a name="week-4"></a>
 Ideas here are adapted from [Atomic Habits by James Clear](https://bookshop.org/books/atomic-habits-an-easy-proven-way-to-build-good-habits-break-bad-ones/9780735211292)
 
-1. Assess your habits from week 3: how did you spend your time this past week? What was effective in your habits? What could be more effective? What steps will you take to make that happen? 
+1. Assess your habits from week 3: how did you spend your time this past week? What was effective in your habits? What could be more effective? What steps will you take to make that happen?
 
 2. Implement a reiforcement strategy: to make one of your habits more satisfying, what is a reward you can give yourself immediately after completing the habit? How will this reward encourage you to continue completing that habit?
 
 3. "Don't Break the Chain": Use a habit tracker
 * What is a habit that you want to make sure to do *every day*? How could you visually cue yourself to complete it (i.e., moving a paper clip)? How can you visually track it each time you've completed it? Could you automate the tracking? How will you do that?
 * Need help? Check out one of these [habit tracking apps](https://www.lifehack.org/668261/best-habit-tracking-apps)
- 
+
 4. How to get back on track when missing a habit: if you miss a day or two of completing your habit, how will you get yourself going again?
 
-5. Pick an accountability partner (your cohort accountabilibuddy, your mentor, a close friend, etc.) and create a habit contract with them. How often will you check in with each other? How will they hold you accountable? 
+5. Pick an accountability partner (your cohort accountabilibuddy, your mentor, a close friend, etc.) and create a habit contract with them. How often will you check in with each other? How will they hold you accountable?
 
 ### Mod 2 Week 5: Outreach & Networking I  <a name="week-5"></a>
-Review your habit tracker: how did you monitor your habit(s)? What does this tell you about your overall progress becoming the person you want to be? In general, how satisfied are you with how you spent your time this module? What could be improved next module? 
+Review your habit tracker: how did you monitor your habit(s)? What does this tell you about your overall progress becoming the person you want to be? In general, how satisfied are you with how you spent your time this module? What could be improved next module?
 
 Mind Maps:
 * 1. **Engagement.** What did you reflect on last week in regards to when you're engaged in your work at Turing? Pull out an idea that resonates with you most (e.g., "Talking through a problem with a partner," "The moment when I solve a problem that I previously didn't know how to do," "Setting up a successful project management process for my team") and break that idea down into parts and make a list (what are all the steps that go into that moment? When do you get to use your strengths? What is fun about this?).
 * 2. **Energy.** What did you reflect on last week in regards to when you feel most energized in your work at Turing? Pull out an idea that resonates with you most and break that idea down into parts and make a list (what are all the steps that go into that moment? When do you get to use your strengths? What is fun about this?).
 * 3. **Flow.** When have you had an experience recently in which you were in a state of flow? You can also think about this as "joy" or "play." Pull out an idea that resonates with you most and break that idea down into parts and make a list (what are all the steps that go into that moment? When do you get to use your strengths? What is fun about this?).
 
-Prototype your mind maps: what do these mind maps tell you about what's important to you as a software developer? What questions do they bring up about what you still want to learn about this career? 
+Prototype your mind maps: what do these mind maps tell you about what's important to you as a software developer? What questions do they bring up about what you still want to learn about this career?
 
 Prototype your outreach: (Be prepared to share this in your small group discussion)
 * Who comes to mind as a person you can reach out to? Why that person? What questions would you ask them? Come up with 2-3 people here to serve as prototypes
 * How would this outreach help you further your job search strategy?
 
-Outreach & Networking Plan: Based on your reflections above, create a concrete plan for your outreach: 
-* Who is the right person for you to reach out to? 
+Outreach & Networking Plan: Based on your reflections above, create a concrete plan for your outreach:
+* Who is the right person for you to reach out to?
 * How will you find them? How do you know they’re the right person?
 * How will you reach out?
 * What questions do you need to ask them?
 * How will you use this information to further your solution?
-* How will you follow up? 
+* How will you follow up?
 
 Execute your plan:
 * Reach out to your contact THIS WEEK. If possible, reach out to more than one person OR find a meetup to attend also. What happened? What other next steps should you take? If this is a person connected to a company you're interested in, be sure to add it to your Huntr card.

--- a/module_two/week_1_habits_part_ii.md
+++ b/module_two/week_1_habits_part_ii.md
@@ -17,7 +17,7 @@ Ideas in this session are adapted from [Atomic Habits by James Clear](https://bo
 * Implement temptation bundling to improve your motivation
 * Apply new strategies within your environment design and everyday process to break down procrastination
 
-### [This Week's Career Journal Prompts](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md#week-1)
+### [This Week's Career Journal Prompts](/module_two/mod2_career_journal_prompts#week-1)
 
 * Reflect on habits from last mod
 * Set intentions for this mod
@@ -29,27 +29,27 @@ Ideas in this session are adapted from [Atomic Habits by James Clear](https://bo
 ### Review
 Consider:
 
-* What is something that is easier, more automatic for you to do now than when you started at Turing? 
+* What is something that is easier, more automatic for you to do now than when you started at Turing?
 * What specific behaviors and processes led to that becoming easier for you?  
 
-These examples are habits, born out of feedback loops where we try different things to see what works in order to solve a problem. Think of habits as your own personal algorithm that you follow each time you want to solve that exact type of problem. Want to feel more alert in the morning? Drinking a cup of coffee will solve that problem; therefore, a large majority of Americans have a daily habit of drinking coffee in the morning. We've become programmed to respond with that habit to solve that particular problem. 
+These examples are habits, born out of feedback loops where we try different things to see what works in order to solve a problem. Think of habits as your own personal algorithm that you follow each time you want to solve that exact type of problem. Want to feel more alert in the morning? Drinking a cup of coffee will solve that problem; therefore, a large majority of Americans have a daily habit of drinking coffee in the morning. We've become programmed to respond with that habit to solve that particular problem.
 
 #### Outcomes-Based Habits vs. Identity-Based Habits
 When we talk about habits, we have to be clear what *kind* of habits we're talking about. We traditionally think about our habits as outcome-based; that is, we focus on the results that a certain habit can achieve. That's all well and good for a short-term or one-time habit, but when we think about making lasting change, we want to focus more on habits that are based in our identities.
 
-Why? Our identities inform our habits (and vice versa). If we want different habits, we need to think about the kind of identity we want to inhabit. This means we have to shift our thinking from outcome-based ("I want this") to identity-based ("I am this"). The process of building habits is the process of adding/updating your identity to become the person you want to be. If the goal is to become an effective software developer, you need to reframe your thinking from "I want to be an effective software developer" to "I **am** an effective software developer" and then make sure you have the right habits in place to affirm your identity. 
+Why? Our identities inform our habits (and vice versa). If we want different habits, we need to think about the kind of identity we want to inhabit. This means we have to shift our thinking from outcome-based ("I want this") to identity-based ("I am this"). The process of building habits is the process of adding/updating your identity to become the person you want to be. If the goal is to become an effective software developer, you need to reframe your thinking from "I want to be an effective software developer" to "I **am** an effective software developer" and then make sure you have the right habits in place to affirm your identity.
 
 Reading from Mod 1 on this topic: [Identity-Based Habits: How to Actually Stick to Your Goals This Year](https://jamesclear.com/identity-based-habits)
 
 #### Goals vs. Systems
-What is the difference between goals and systems? 
+What is the difference between goals and systems?
 
 * Goals are focused on the results you want to achieve
 * Systems are the processes to get there
 
 What should we prioritize when it comes to our behaviors? Systems
 
-Why? 
+Why?
 1. Goals are restrictive
 2. Goals are a momentary change
 3. Systems are ongoing -- create lasting change
@@ -57,23 +57,23 @@ Why?
 
 Bottom line: habits free up cognitive space so that you can learn something new
 
-This week's [career journal prompts #1 and #2](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md#week-1) ask you to reflect on last module's habits and think about the intentions you want to create for this module
+This week's [career journal prompts #1 and #2](/module_two/mod2_career_journal_prompts#week-1) ask you to reflect on last module's habits and think about the intentions you want to create for this module
 
 ### 2nd Law of Behavior Change: Make It Attractive
-In Mod 1, we introduced the [4 laws of behavior change](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_one/week_3_building_habits.md) and spent time looking at the first one: *make it obvious.* For ineffective habits, the inverse is needed: *make it invisible.*
+In Mod 1, we introduced the [4 laws of behavior change](/module_one/week_3_building_habits) and spent time looking at the first one: *make it obvious.* For ineffective habits, the inverse is needed: *make it invisible.*
 
 Now, let's look at the 2nd law of behavior change: *make it attractive.* The more attractive an opportunity is, the more likely it is to become habit-forming
 
-How does something become attractive? It is the expectation of a reward at the end that motivates us to act at all, which leads us to the idea of temptation bundling -- linking an action you want to do with an action you need to do. Read [this article from Clear to find out more.](https://jamesclear.com/temptation-bundling) 
+How does something become attractive? It is the expectation of a reward at the end that motivates us to act at all, which leads us to the idea of temptation bundling -- linking an action you want to do with an action you need to do. Read [this article from Clear to find out more.](https://jamesclear.com/temptation-bundling)
 
 ### 3rd Law of Behavior Change: Make it Easy
-We talk a lot about putting in reps when coding; why? Because the most effective form of learning is practice, not planning. 
+We talk a lot about putting in reps when coding; why? Because the most effective form of learning is practice, not planning.
 
 So, how can you apply that to your habits? To master a habit, the key is to start with repetition, not perfection. We are motivated by what is most easy for us, and the more we practice something, the easier it will be. Read [this article to understand this more fully.](https://jamesclear.com/repetitions)
 
-In this same section of *Atomic Habits,* Clear writes: “One of the most effective things you can do to build better habits is to join a culture where 1. your desired behavior is the ‘normal’ behavior and 2. you already have something in common with the group.” 
+In this same section of *Atomic Habits,* Clear writes: “One of the most effective things you can do to build better habits is to join a culture where 1. your desired behavior is the ‘normal’ behavior and 2. you already have something in common with the group.”
 
-Consider: 
+Consider:
 
-* How can we build a culture within our cohorts where the desired behavior we all want to express is our collective norm? 
+* How can we build a culture within our cohorts where the desired behavior we all want to express is our collective norm?
 * How will we encourage and hold each other accountable to holding effective habits throughout the entire module?

--- a/module_two/week_2_professional_storytelling_branding.md
+++ b/module_two/week_2_professional_storytelling_branding.md
@@ -11,7 +11,7 @@ subheading: Crafting Your Professional Narrative
 * Create your personal brand as a software developer
 * Tell your story effectively across multiple platforms
 
-### [This Week's Career Journal](https://github.com/turingschool/career-development-curriculum-site/blob/master/module_two/mod2_career_journal_prompts.md#week-2)
+### [This Week's Career Journal](/module_two/mod2_career_journal_prompts#week-2)
 * Draft of professional story
 * Update your LinkedIn and include a link to your profile
 * Create next steps for any other branding tools
@@ -31,15 +31,15 @@ From your professional story, we'll craft your resume, your Turing portfolio, up
 ## Professional Storytelling
 We are all inherent storytellers. Stories are how we connect with each other. From fairy tales to novels to movies to podcasts, stories provide a way for people to share their experiences with others, building empathy and awareness of our universal experiences.
 
-Storytelling is our first step in the job search at Turing. You are a member of the software industry now, and as you start connecting with others in the industry, you need to be able to tell the story of your transition -- how did you get here? How do you uniquely make up a part of this industry? 
+Storytelling is our first step in the job search at Turing. You are a member of the software industry now, and as you start connecting with others in the industry, you need to be able to tell the story of your transition -- how did you get here? How do you uniquely make up a part of this industry?
 
 Let's start by thinking about stories. What do you love about stories? Emma Coats, a former story artist for Pixar, shared her [22 rules for storytelling here](https://www.washingtonpost.com/blogs/comic-riffs/post/pixar-tips-brave-artist-emma-coats-shares-her-storytelling-wit-and-wisdom-on-twitter%20followher/2012/06/25/gJQADaxd2V_blog.html), and we'll use some of them to apply them to our storytelling. We're going to start with rule #10:
 
-    Pull apart the stories you like. What you like in them is a part of you; 
+    Pull apart the stories you like. What you like in them is a part of you;
     you’ve got to recognize it before you can use it.
 
-Consider: 
-* What is a story that has inspired you in the past? 
+Consider:
+* What is a story that has inspired you in the past?
 * Why has that story stuck with you?
 
 ### Elements of a Story
@@ -65,14 +65,14 @@ These elements are present in your story as well. You are the main character, th
 There are 3 main questions to help us understand our own stories and our character arcs:
 * **Who are you?** *(as a developer, a teammate, a worker, a career changer)*
 * **Why are you here?** *(Why software development? Why now? Consider both your background but also what drives you to be in this field)*
-* **What's next?** *(Where do you see yourself going in this career?)* 
+* **What's next?** *(Where do you see yourself going in this career?)*
 
 ### How to Tell Your Story
 Telling the story of your professional transition into software development helps others understand your motives, character, and capacity to reach the goals that you've set for yourself. In short, your story makes others believe in you.
 
-Your story is one of **transition.** These stories are inherently interesting as they have all the elements of a classic story, and most importantly, they have the important elements of change, conflict, and tension around the transition. Where are you going? What will happen next? It's so exciting for the listener! But it also depends on how you tell that story. 
+Your story is one of **transition.** These stories are inherently interesting as they have all the elements of a classic story, and most importantly, they have the important elements of change, conflict, and tension around the transition. Where are you going? What will happen next? It's so exciting for the listener! But it also depends on how you tell that story.
 
-**Disclaimer:** When we say story, this is not something that has been made up or embellished in any way. People can tell when you're not being truthful. Rather, this is about how to make a true account of a career trajectory engaging and inspiring. 
+**Disclaimer:** When we say story, this is not something that has been made up or embellished in any way. People can tell when you're not being truthful. Rather, this is about how to make a true account of a career trajectory engaging and inspiring.
 
 During a networking event explored in this [Harvard Business Review article](https://hbr.org/2005/01/whats-your-story), senior managers who'd been downsized took turns telling what they had done before and what they were looking for next. Here are some takeaways:
 
@@ -80,18 +80,18 @@ During a networking event explored in this [Harvard Business Review article](htt
 * Stories that focus more on character motives, themes, and turning points -- the moments that cause your listener to ask, *"What happened next?"* -- are compelling to a listener.
 
 ## Application: Telling Your Story through Branding
-Personal branding is all about telling a consistent story about yourself, building out the details of this story with each profile. As you start this new career, telling your story as a new member of the software industry in as many consistent ways as possible will help you stand out and embrace that identity even more. 
+Personal branding is all about telling a consistent story about yourself, building out the details of this story with each profile. As you start this new career, telling your story as a new member of the software industry in as many consistent ways as possible will help you stand out and embrace that identity even more.
 
 Why is this important? According to the online reputation management consultantcy, [BrandYourself](https://brandyourself.com/):
 
 * 82% of business decision makers said that presence in search results was an influential factor when vetting people online.
 * 42% of US adults looked someone up before deciding to do business with them.
 * 27% have searched for someone they met in a professional setting, such as a networking event.
-* 23% of US adults have looked up a coworker. 
+* 23% of US adults have looked up a coworker.
 
 ### Tools to Create Your Personal Brand
 #### LinkedIn
-LinkedIn is specifically set up to utilize algorithms and context to help employers find potential candidates and vice versa. As we look at LinkedIn today, we'll talk about how you can passively use it for your job search -- how do people find you? How do they know who you are? It all has to do with how you tell your stories and the particular keywords that you're using. If you don't already have a LinkedIn profile, now is time to set one up [here](https://www.linkedin.com/). 
+LinkedIn is specifically set up to utilize algorithms and context to help employers find potential candidates and vice versa. As we look at LinkedIn today, we'll talk about how you can passively use it for your job search -- how do people find you? How do they know who you are? It all has to do with how you tell your stories and the particular keywords that you're using. If you don't already have a LinkedIn profile, now is time to set one up [here](https://www.linkedin.com/).
 
 #### Dissecting the Profile
 **First Look:**
@@ -102,31 +102,31 @@ The top of your profile is an opportunity to make a great first impression. When
 * **Your location:** Where do you want to be? If you want to work in San Francisco, list San Francisco
 * **The first few sentences of your summary:** This is why it's so important. Make those first 100 words stand out.
 
-**Headline:** 
+**Headline:**
 
 * This is your expertise
-   * What do you want your brand to be? 
-   * When recruiters do a search, what keywords do you want to lead to you? 
+   * What do you want your brand to be?
+   * When recruiters do a search, what keywords do you want to lead to you?
 	* Consider "Software Developer," "Back End Engineer," or "Front End Engineer"
 	* You can combine your past experiences with new skills like "Software Developer | Former Educator"
-	* Consider adding in languages/frameworks you specialize in 
+	* Consider adding in languages/frameworks you specialize in
    * Any keywords here should be consistently displayed throughout your profile
 
-**Summary:** 
+**Summary:**
 This is the story that you're telling: who you are (as a developer, worker, teammate, individual, etc.), how you got here (why software development, why now), what's next (what are your longterm career goals/ambitions). Your story is one of the few places in the profile where you can introduce yourself as a whole person and should be told from a high level.
 
 Tips for an effective summary:
 
 * Keep it to 2-3 short paragraphs, 2-3 sentences per paragraph
 * Write it in first person
-* Provide a call to action -- what do you want people to do when they see your profile? Do you want them to look at your code, website, email you? 
+* Provide a call to action -- what do you want people to do when they see your profile? Do you want them to look at your code, website, email you?
 	* Put your email address right there in the summary. Once you get a job, you can take it out, but don't create any blockers right now
-	
+
 **Examples: What can a LinkedIn summary look like?**
 * Merge your past experience with your new career path:
    * “Combining marketing experience with a love for data, I’m a software developer looking to…”
 * What are your motives?
-   * “My love for helping people led me to develop apps that focus on the user experience…” 
+   * “My love for helping people led me to develop apps that focus on the user experience…”
 * What do you enjoy working with? Mention your specialities (aka keywords):
    * “Along with my experience in client-side development, I have been learning and working with Node, Express, Knex, PostgreSQL and RESTful API creation to fill out my server-side experience.”
 
@@ -135,12 +135,12 @@ Still need convincing that you need a summary?
 * Remember: 82% of business decision makers said that presence in search results was an influential factor when vetting people online
 * A summary is an easy way for someone to learn specifically about you when searching for candidates
 
-**Work Experience:** 
+**Work Experience:**
 As you list your past experiences, your accompanying description should not be bullet points. Why? It doesn't read as well on LinkedIn and interferes with keyword searches. LinkedIn is also built out to be a *storytelling platform*, so use it that way. Write in complete sentences and paragraphs. Think about how you read across a computer screen. You want your profile to be easy to scan since recruiters only have so much time to look at them.
 
 * Focus on applicable and transferable skills; Again, consider keyword searches
-* Instead of listing tasks, discuss value of your past work. 
-   * What value did you bring to this company? 
+* Instead of listing tasks, discuss value of your past work.
+   * What value did you bring to this company?
 * Link to the name of the company
    * List Turing under experience but clearly state that you're a student
    * Edit your title to "Software Developer Student," "Back End Engineering Student," or "Front End Engineering Student"
@@ -161,12 +161,12 @@ To edit your URL, click on "edit your public profile" on the righthand side of t
 * You can make your LinkedIn in multiple languages to address and attract different communities. This is effective if you'd like to work abroad
 
 **Career Interests Button:**
-Below your summary, on your personal dashboard, there is an option to update your career interests to let recruiters know if you're actively, passively, or not looking for opportunities. You can update this if you'd like to let recruiters know more specifically about your interests. Be warned -- you may open yourself up to lots of contacts if you click it on, and they may not always be helpful. But this would also increase your conversations with recruiters, which at the very least could be a good learning opportunity. 
+Below your summary, on your personal dashboard, there is an option to update your career interests to let recruiters know if you're actively, passively, or not looking for opportunities. You can update this if you'd like to let recruiters know more specifically about your interests. Be warned -- you may open yourself up to lots of contacts if you click it on, and they may not always be helpful. But this would also increase your conversations with recruiters, which at the very least could be a good learning opportunity.
 
 **Add Connections**
 Your network & their relevance to the job you want DO matter -- start connecting with peers in the industry!
 * Aim for at least 100 connections
-* Quality over quantity 
+* Quality over quantity
 * When adding Turing staff/alumni, please include an introductory message.                                          
 * Engage with your connections by liking, commenting on, and/or sharing their updates.
 * As you continue to grow in your development at Turing, share your own updates, whether they be blog posts or links to projects.
@@ -179,7 +179,7 @@ Your network & their relevance to the job you want DO matter -- start connecting
 * [Matt Kaufman](https://www.linkedin.com/in/matthew-leo-kaufman/)
 
 #### GitHub Overview
-You already have a GitHub profile -- make sure it looks good! 
+You already have a GitHub profile -- make sure it looks good!
 
 - Add a headshot photo rather than using the avatar to look more professional
 - Complete your GitHub profile with:
@@ -192,7 +192,7 @@ You already have a GitHub profile -- make sure it looks good!
 * File issues on all your repos for things that need fixing up
 
 #### Twitter Overview
-You don't *have* to have a Twitter account. But a lot of software developers (aka the people you want to connect with) are using Twitter, so we would highly recommend that you create a profile if you don't have one already! 
+You don't *have* to have a Twitter account. But a lot of software developers (aka the people you want to connect with) are using Twitter, so we would highly recommend that you create a profile if you don't have one already!
 
 Twitter allows you to:
 

--- a/resources/branding_resources.md
+++ b/resources/branding_resources.md
@@ -13,6 +13,6 @@ title: Resources for Building Your Brand as a Software Developer
 * [Follow the steps suggested here for auditing your projects](http://backend.turing.io/module4/lessons/project_polish)
 
 ## Miscellaneous <a name="miscellaneous"></a>
-* [Tips for Writing Technical Blog Posts](https://github.com/turingschool/career-development-curriculum/blob/master/module_four/blogging_tips.md)
+* [Tips for Writing Technical Blog Posts](/module_four/blogging_tips)
 * [Open Source Guide](https://opensource.guide/)
-* [Tips for Speaking at a Meetup](https://github.com/turingschool/career-development-curriculum/blob/master/module_four/meetup_involvement_guidelines.md)
+* [Tips for Speaking at a Meetup](/module_four/meetup_involvement_guidelines)

--- a/resources/index.md
+++ b/resources/index.md
@@ -4,21 +4,21 @@ title: Career Development Resources
 ---
 
 # Career Development Resources
-Below are a list of additional resources to help you with your career development and job search. 
+Below are a list of additional resources to help you with your career development and job search.
 
 ### Storytelling & Branding Resources
-* [Resources for Building Your Brand as a Software Developer](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/branding_resources.md)
+* [Resources for Building Your Brand as a Software Developer](/resources/branding_resources)
 
 ### Finding Opportunities Resources
-* [Listing of various tools for finding opportunities](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/finding_opportunities.md)
+* [Listing of various tools for finding opportunities](/resources/finding_opportunities)
 
 ### Application Resources
-* [Resume Resources](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/resume_resources.md)
-* [Cover Letter Resources](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/cover_letter_resources.md)
-* [Outreach & Networking Resources](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/outreach_networking_resources.md)
+* [Resume Resources](/resources/resume_resources)
+* [Cover Letter Resources](/resources/cover_letter_resources)
+* [Outreach & Networking Resources](/resources/outreach_networking_resources)
 
 ### Interview Prep Resources
-* [Compilation of Lots of Interview Prep Resources](https://github.com/turingschool/career-development-curriculum-site/blob/master/resources/interview_prep_resources.md)
+* [Compilation of Lots of Interview Prep Resources](/resources/interview_prep_resources)
 
 ### Recommended Reading
 * [Atomic Habits](https://bookshop.org/books/atomic-habits-an-easy-proven-way-to-build-good-habits-break-bad-ones/9780735211292)

--- a/resources/outreach_networking_resources.md
+++ b/resources/outreach_networking_resources.md
@@ -3,8 +3,8 @@ layout: page
 title: Outreach & Networking
 ---
 
-# Outreach & Networking 
-Below are both resources and outlined steps for taking on outreach and networking for your job search. 
+# Outreach & Networking
+Below are both resources and outlined steps for taking on outreach and networking for your job search.
 
 ### Research Your Contacts
 * Start with LinkedIn
@@ -18,7 +18,7 @@ Below are both resources and outlined steps for taking on outreach and networkin
 * Suggest meeting times
 
 ### Finding Emails
-* Start by searching the person's GitHub! 
+* Start by searching the person's GitHub!
 * [Email Hunter](https://emailhunter.co/)
 * [Find That Lead](https://findthatlead.com/)
 * [Find That Email](https://findthat.email/)
@@ -31,20 +31,20 @@ Below are both resources and outlined steps for taking on outreach and networkin
 ### Prepare for Coffee Meetings
 * Using your research, prepare some questions to ask your contact
 * Start here:
-   * [Research Converation Questions](https://github.com/turingschool/career-development-curriculum/blob/master/module_four/research_conversation_questions.md)
+   * [Research Converation Questions](/module_four/research_conversation_questions)
    * [Culture Queries Generator](https://www.keyvalues.com/culture-queries)
    * [LOTS of Additional Questions](https://yangshun.github.io/tech-interview-handbook/questions-to-ask)
    * End the conversation by asking, "who else from your network could you introduce me to?"
 
 ### Networking Groups for Underrepresented People in Tech
 * [BeVisible](https://www.bevisible.soy/) is a career network for Latinx.
-* [Black Data Processing Associates](https://www.bdpa.org/default.aspx) is an international organization for Black professionals in tech. 
+* [Black Data Processing Associates](https://www.bdpa.org/default.aspx) is an international organization for Black professionals in tech.
 * [CodeNewbie](https://www.codenewbie.org/) is a community for newcomers to code.
-* [Diversify Tech](https://www.diversifytech.co/) is a community built to share upcoming conference scholarships, events, education scholarships, job opportunities, and more for people who are underrepresented in tech. 
-* [Lesbians Who Tech](https://lesbianswhotech.org/) is a career network for lesbians. 
-* [MAES](http://mymaes.org/) was founded in Los Angeles in 1974 to increase the number of Mexican Americans and other Hispanics in the technical and scientific fields. 
+* [Diversify Tech](https://www.diversifytech.co/) is a community built to share upcoming conference scholarships, events, education scholarships, job opportunities, and more for people who are underrepresented in tech.
+* [Lesbians Who Tech](https://lesbianswhotech.org/) is a career network for lesbians.
+* [MAES](http://mymaes.org/) was founded in Los Angeles in 1974 to increase the number of Mexican Americans and other Hispanics in the technical and scientific fields.
 * [National Society of Black Engineers](http://www.nsbe.org/home.aspx) is one of the largest student-governed organizations with the aim to increase the number of culturally responsible Black Engineers.
-* [Out in Tech](https://outintech.com/#welcome) is a community to connect LGBTQ+ in tech. 
+* [Out in Tech](https://outintech.com/#welcome) is a community to connect LGBTQ+ in tech.
 * [TechLatino](http://techlatino.org/) is an organization to empower Latino technological and scientific engagement.
 * [Tech Ladies](https://www.hiretechladies.com/) is a community for women and non-binary folks. You have to apply to join, but once accepted, you'll have access to jobs from partnering companies.
-* [Trans Tech Social Enterprises](https://www.transtechsocial.org/) is an incubator for LGBTQ Talent with a focus on economically empowering transgender people. 
+* [Trans Tech Social Enterprises](https://www.transtechsocial.org/) is an incubator for LGBTQ Talent with a focus on economically empowering transgender people.

--- a/session_archives/cold_outreach_i.md
+++ b/session_archives/cold_outreach_i.md
@@ -13,7 +13,7 @@ title: Cold Outreach I
 
 ### Deliverable
 
-You'll be expected to give a synopsis of your cold outreach interactions following these [guidelines](cold_outreach_i_guidelines.md) via the [PD submissions repo](https://github.com/turingschool/career-development-curriculum/tree/master/deliverable_submissions)
+You'll be expected to give a synopsis of your cold outreach interactions following these [guidelines](cold_outreach_i_guidelines) via the [PD submissions repo](https://github.com/turingschool/career-development-curriculum/tree/master/deliverable_submissions)
 
 ### Opening
 

--- a/session_archives/m4_old_outreach_networking_session.md
+++ b/session_archives/m4_old_outreach_networking_session.md
@@ -4,7 +4,7 @@ title: Networking
 ---
 
 #### Option 1: Cold Outreach
-Start to meet others in the industry through informal research conversations. How do you meet them? Send them a cold outreach email and then set up a coffee meeting. To fulfill this deliverable, provide a synopsis of 6 cold outreach interactions following these [guidelines](cold_outreach_deliverable_guidelines.md) by **Monday of Week 5**
+Start to meet others in the industry through informal research conversations. How do you meet them? Send them a cold outreach email and then set up a coffee meeting. To fulfill this deliverable, provide a synopsis of 6 cold outreach interactions following these [guidelines](cold_outreach_deliverable_guidelines) by **Monday of Week 5**
 
 #### Option 2: Speak at a Meetup
 Many Meetups are interested in having new people come speak to their communities, and beginner's tracks are the norm at many major Meetups. Contact the Meetup organizers, propose a talk idea (this can be about anything!), and get on their list. If you start to make this habit, organizers will begin to contact *you* when they need someone to fill in. This is a great opportunity to meet people and help out local meetups. To complete this deliverable, submit a gist by **Monday of Week 5** listing:  

--- a/session_archives/mod_4_action_plan_template.md
+++ b/session_archives/mod_4_action_plan_template.md
@@ -3,7 +3,7 @@ layout: page
 title: Template: Module 4 Action Plan
 ---
 
-*This is your deliverable from the [Job Search Strategies I session](job_search_strategies_i.md)*
+*This is your deliverable from the [Job Search Strategies I session](job_search_strategies_i)*
 
 ## Module 4 Goals
 


### PR DESCRIPTION
# On Homepage

* Subheading under Career Development Curriculum could read: “Your guide to a successful new career in software.” ...or something like that
* Add button for Mod 5 at top
* Add button for Resources at top
* For content on page, use ReadMe
* Take out:
    * Paired section
    * Calendar
    * Mentor list
    * Move mental health to the top?

# Module pages

When linking to anything from the module index pages, can they show up in the same format on the site and not link to the markdown?
